### PR TITLE
#18 - Allow default layouts to visually render markdown to html. 

### DIFF
--- a/themes/jb/layouts/_default/list.html
+++ b/themes/jb/layouts/_default/list.html
@@ -2,7 +2,14 @@
 
 <div class="container">
   <h1 class="title">{{.Title}}</h1>
-  {{.Content}}
+</div>
+
+<div class="container">
+
+    <div class="column is-full content">
+      {{.Content}}
+    </div>
+
 </div>
 
 {{ $lastUrlElement := index (last 1 (split (delimit (split .Permalink "/") "," "") ",")) 0 }}

--- a/themes/jb/layouts/_default/single.html
+++ b/themes/jb/layouts/_default/single.html
@@ -1,8 +1,15 @@
 {{ define "main" }}
 
-  <div class="container">
-    <h1 class="title">{{.Title}}</h1>
-    {{.Content}}
-  </div>
+<div class="container">
+  <h1 class="title">{{.Title}}</h1>
+</div>
+
+<div class="container">
+
+    <div class="column is-full content">
+      {{.Content}}
+    </div>
+
+</div>
 
 {{ end }}


### PR DESCRIPTION
Fixes #18 for pages without an explicitly defined layout.