### PR TITLE
Add Garage Sale menu item via URL

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -32,6 +32,12 @@ paginate = 12
     weight =-90
 
 [[Menu.Main]]
+    name = "Garage Sale"
+    identifier = "garage-sale"
+    url = "https://www.jupitergarage.com/"
+    weight =60
+
+[[Menu.Main]]
     name = "Membership"
     identifier = "membership"
     url = "/membership"


### PR DESCRIPTION
Would be extra nice to have this Garage Sale menu URL open in a new tab/window - see #47 