### PR TITLE
Feat/updating to use pipenv

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -37,7 +37,7 @@ jobs:
     - name: 'Scrape'
       run: |
         cd ./show-scraper
-        DATA_DIR=../jbsite LATEST_ONLY=true pipenv run scraper.py
+        DATA_DIR=../jbsite LATEST_ONLY=true pipenv run ./scraper.py
 
     - name: 'Commit'
       uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -25,18 +25,19 @@ jobs:
         path: ./show-scraper
 
     - name: 'Setup Python'
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v3
       with:
         python-version: '3.10'
         architecture: 'x64'
+        cache: "pipenv"
     
     - name: 'Install Python deps'
-      run: pip install -r ./show-scraper/requirements.txt
+      run: pip install pipenv && cd ./show-scraper && pipenv sync --bare
 
     - name: 'Scrape'
       run: |
         cd ./show-scraper
-        DATA_DIR=../jbsite LATEST_ONLY=true python scraper.py
+        DATA_DIR=../jbsite LATEST_ONLY=true pipenv run scraper.py
 
     - name: 'Commit'
       uses: stefanzweifel/git-auto-commit-action@v4


### PR DESCRIPTION
Updating the scrapper to use pipenv instead of normal python + pip, more info here: https://github.com/JupiterBroadcasting/show-scraper/pull/12

:arrow_up: needs to be merged **before** this PR is accepted, or else the scraper will not work.


Tried out with my own fork here: https://github.com/elreydetoda/jupiterbroadcasting.com/runs/7383479441