### PR TITLE
adding reference to auto closing issues with PR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,9 @@ A:
 > * some tickets are specifically labeled "low priority", but others are so far of fairly equal importance. Anytime there is something clearly urgent, the "urgent" tag will be used.
 
 ### Issue assignment for work in progress
-* Note: currently non-organisation members cannot self-assign.
+* Note:
+  * currently non-organisation members cannot self-assign.
+  * if you're closing a specific issue you can use [Github's closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to automatically close the issue once it's merged.
 
 Q:
 > Since I’ve not worked with a team using git/GitHub, is the etiquette to assign a issue to ourselves if we are working on it or just comment on the issue saying we are working on it?


### PR DESCRIPTION
I've noticed that there are some issues that have had PRs reference them and are merged but the issue wasn't closed.

A nice things with GH (GitHub) is that you can auto close issues when PRs are merged. One way is just from the web-ui before it's merged (under linked issues I think), and the other way is to use the special keywords that I linked to.
So, if we mention that to people who want to contribute it might allow closing of issues more easily instead of remembering to close it later.