### PR TITLE
Feat/show page linking/84

### DIFF
--- a/themes/jb/assets/css/libs/bulma/_components.sass
+++ b/themes/jb/assets/css/libs/bulma/_components.sass
@@ -1,7 +1,7 @@
 /* Bulma Components */
 @charset "utf-8"
 
-//@import "sass/components/breadcrumb"
+@import "sass/components/breadcrumb"
 @import "sass/components/card"
 @import "sass/components/dropdown"
 //@import "sass/components/level"

--- a/themes/jb/layouts/episode/single.html
+++ b/themes/jb/layouts/episode/single.html
@@ -4,6 +4,13 @@
 
 {{ define "main" }}
   <div class="container p-4">
+      <nav class="breadcrumb" aria-label="breadcrumbs">
+        <ul>
+          <li><a href="{{ .Section | safeURL | absURL }}">Shows</a></li>
+          <li><a href="{{ .Parent.Permalink }}">{{ .Params.show_name }}</a></li>
+          <li class="is-active"><a href="{{ .Permalink }}">{{ .Title }}</a></li>
+        </ul>
+      </nav>
       <div class="content">
         <h1>{{ .Title }}
           {{ if ne .Title (print .CurrentSection.Title " " .Params.episode) }} 


### PR DESCRIPTION
@gerbrent, is this what you were thinking of when you created #84? (the red box isn't in the HTML, just using it to point out where I was asking about)

![image](https://user-images.githubusercontent.com/10230166/179661734-1357a084-197e-4a5c-8c17-0a9f73d81f47.png)

and when section title is different then content title (i.e. [this part](https://github.com/JupiterBroadcasting/jupiterbroadcasting.com/blob/551e71a20d01b5fa9c8b87fd7d66dbc7613c116e/themes/jb/layouts/episode/single.html#L9-L10) in the code)

![image](https://user-images.githubusercontent.com/10230166/179661961-b8620dd3-785a-427e-a6d6-f65ecb91dc85.png)


I figure a breadcrumb would be the easiest for users to wrap their heads around navigating backup to the show page.

closes #84 