### PR TITLE
adding slight padding for mobile

### DIFF
--- a/themes/jb/layouts/episode/single.html
+++ b/themes/jb/layouts/episode/single.html
@@ -3,7 +3,7 @@
 {{end}}
 
 {{ define "main" }}
-  <div class="container">
+  <div class="container p-4">
       <div class="content">
         <h1>{{ .Title }}
           {{ if ne .Title (print .CurrentSection.Title " " .Params.episode) }} 


### PR DESCRIPTION
Don't know if this is the right spot to use this (just using an inline bulma class), but for the episodes they looked really squished on a mobile view (using dev tools to resize screen).

![image](https://user-images.githubusercontent.com/10230166/179667036-e9e402cb-785f-4f23-b1e3-7792f7f04a54.png)

So, I added a slight padding to the container and it looks a lot better (1 rem).

![image](https://user-images.githubusercontent.com/10230166/179667140-79092601-5703-4a49-ad73-4dd416d0718f.png)

Just a small improvement, and again sorry if this isn't the right place to add this (let me know and I can modify the other location), but it looks a lot better (to me at least :sweat_smile: ).