### PR TITLE
Feat/css pipelining

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: jakejarvis/hugo-build-action@master  # ...or replace 'master' with a full version tag, such as: v0.64.1
       with:
-        args: --gc --config ./config.toml
+        args: --gc --config ./config.toml --environment prod
     - uses: burnett01/rsync-deployments@4.1
       with:
        switches: -avzr --delete
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: jakejarvis/hugo-build-action@master  # ...or replace 'master' with a full version tag, such as: v0.64.1
       with:
-        args: --gc --config config.coder-radio.toml
+        args: --gc --config config.coder-radio.toml --environment prod
     - uses: burnett01/rsync-deployments@4.1
       with:
        switches: -avzr --delete
@@ -51,7 +51,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: jakejarvis/hugo-build-action@master  # ...or replace 'master' with a full version tag, such as: v0.64.1
       with:
-        args: --gc --config config.jblive.toml
+        args: --gc --config config.jblive.toml --environment prod
     - uses: burnett01/rsync-deployments@4.1
       with:
        switches: -avzr --delete

--- a/themes/jb/layouts/partials/head.html
+++ b/themes/jb/layouts/partials/head.html
@@ -5,7 +5,18 @@
   {{ partial "meta.html" . }}
 
   {{ $sass := resources.Get "css/main.sass" }}
-  {{ $style := $sass | resources.ToCSS | resources.Minify }}
+  <!-- Defining options that production & development should have -->
+  {{ $options := (dict "enableSourceMap" true ) }}
+  {{ $style := "" }}
+
+  {{ if hugo.IsProduction }}
+    {{ $options = merge $options (dict "outputStyle" "compressed") }}
+    {{ $style = $sass | toCSS $options | minify | fingerprint }}
+
+  {{ else }}
+    {{ $options = merge $options (dict "outputStyle" "expanded") }}
+    {{ $style = $sass | toCSS $options }}
+  {{ end }}
   <link rel="stylesheet" href="{{ $style.RelPermalink }}">
 
 </head>


### PR DESCRIPTION
This is something I normally do for all my hugo projects (all options have brief explanations [here](https://gohugo.io/hugo-pipes/scss-sass/)) :

1. enable the source map option for hugo's toCSS function (more info [here](https://css-tricks.com/should-i-use-source-maps-in-production/) as to why source map is useful (especially for development))
2. Check if in production (specified with `-e prod` argument for the hugo CLI)
3. If we are, then compress -> minify -> fingerprint
   - If you look at the bottom of [the docs](https://gohugo.io/hugo-pipes/scss-sass/) it says
      > Setting outputStyle to compressed will handle SASS/SCSS files minification better than the more generic [resources.Minify](https://gohugo.io/hugo-pipes/minification/).
      
      but it depends on if we're concatenating CSS files as well (as mentioned [here](https://discourse.gohugo.io/t/hugo-pipes-scss-output-style-compressed-vs-resources-minify/13717/5)). I'm normally doing some type of blending between css & scss, but since we're just doing scss/sass we could leave out the `minify` step.
   - fingerprinting is really useful to help force browsers to pick up new styles whenever they're present (it puts a unique hash at the end to help identify when there are changes and when the browser should/n't cache it).
5. if not (i.e. development), then it'll keep things expanded (which is a lot easier to read)

I also updated the GH action to use the environment flag, so that way it'll do the proper actions in production.