### PR TITLE
modified tags partial styling to be slightly better spaced (IMO)

### DIFF
--- a/themes/jb/assets/css/elements/tag.sass
+++ b/themes/jb/assets/css/elements/tag.sass
@@ -10,5 +10,8 @@ $tag-new-color: $grey-lighter !default
     background-color: darken($tag-background-color, 70%)
 
 .tags
-  .tag a
-    color: $tag-new-color 
+  margin-top: 0.5rem
+  .tag
+    margin: 0.25rem !important
+    a
+      color: $tag-new-color 


### PR DESCRIPTION
The tags under each episode were slight squished against the video player + weren't properly aligned with the word tags.

![image](https://user-images.githubusercontent.com/10230166/179674898-84e99f1a-0f2f-4717-b120-f8380cf763ba.png)

If you enable the [flexbox grid in the developer tools](https://developer.chrome.com/docs/devtools/css/flexbox/), you'll see that all the tags have margin at the bottom and the right (which is causing them to be not centered).

![image](https://user-images.githubusercontent.com/10230166/179675006-b0bac5f6-300e-4193-b4ae-860d6d595963.png)

I still haven't been able to find it even with source map (look at PR #119 for more info) enabled, so my PR includes an `!important` to help override however that's happening. (classes being overridden in pic below)

![image](https://user-images.githubusercontent.com/10230166/179675923-73a83052-fd93-473c-811d-363f3c7d8f88.png)

This is what the tags looks like now, with a slight padding and centered:

![image](https://user-images.githubusercontent.com/10230166/179676121-3f6396fa-af3e-49cd-8aaa-1c1c0ebf4797.png)

You can validate that by looking at the flexbox grid again:

![image](https://user-images.githubusercontent.com/10230166/179676162-11bc8364-a495-40c1-9a65-b47c92e9a6e6.png)

I also added a bit of padding to the top, so that way it's not mushed against the video player anymore.
