### PR TITLE
Feat/swap rss locations/126

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -202,4 +202,5 @@ paginate = 12
 
 [outputs]
   page = ["json","html","webplayer"]
-  section = ["html","rss"]
+  # section = ["html","rss"]
+  section = ["html"]

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -16,6 +16,8 @@ feed.itunes_first_sub_category = "How To"
 feed.itunes_second_sub_category = "Business"
 feed.language = "en-us"
 feed.itunes_type = "episodic"
+feed.rss = "https://feed.jupiter.zone/allshows"
+feed.video_rss = "https://feed.jupiter.zone/allvid"
 
 # Twitch Info
 twitch.channel = "jupiterbroadcasting"

--- a/themes/jb/layouts/partials/meta.html
+++ b/themes/jb/layouts/partials/meta.html
@@ -52,6 +52,8 @@
   <!-- <link href="{{ .Permalink }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
   <link href="{{ .Permalink }}" rel="feed" type="application/rss+xml" title="{{ $.Site.Title }}" /> -->
 {{/* end */}}
+<link href="{{ .Site.Params.feed.rss }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
+<link href="{{ .Site.Params.feed.rss }}" rel="feed" type="application/rss+xml" title="{{ $.Site.Title }}" />
 
 <!-- Meta Pages -->
 <meta property="og:type" content="website" />

--- a/themes/jb/layouts/partials/meta.html
+++ b/themes/jb/layouts/partials/meta.html
@@ -48,10 +48,10 @@
 <!-- Sitemap & RSS Feed Tags -->
 <link rel="sitemap" type="application/xml" title="Sitemap" href="{{ .Site.BaseURL }}sitemap.xml" />
 
-{{ with .OutputFormats.Get "RSS" }}
-  <link href="{{ .Permalink }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
-  <link href="{{ .Permalink }}" rel="feed" type="application/rss+xml" title="{{ $.Site.Title }}" />
-{{ end }}
+{{/* with .OutputFormats.Get "RSS" */}}
+  <!-- <link href="{{ .Permalink }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
+  <link href="{{ .Permalink }}" rel="feed" type="application/rss+xml" title="{{ $.Site.Title }}" /> -->
+{{/* end */}}
 
 <!-- Meta Pages -->
 <meta property="og:type" content="website" />


### PR DESCRIPTION
closes #126 

I did the following:
- removed the rss build step in the config.toml (for the main JB site only)
  - this alone actually reduced my build time immensely! So, even though hugo can do it it's probably good (from a scalability perspective) that we're looking to do it in other ways.
![image](https://user-images.githubusercontent.com/10230166/179988096-cee1a4fb-29ea-47ea-ba93-cb2e727f8e8f.png)
- in the html code I've left all the code in that @StefanS-O used (didn't even touch the list.rss.xml file), but I did
  - a hugo comment `{{/* */}}` to prevent it from trying to call (it used a `with` though so it would've been fine either way)
  - then commented out the HTML code inside the template
- Added the 2 All shows RSS feeds to the config.toml (audio + video)
- Only am calling the audio all shows feed in the `meta.html` page though

Let me know if there is anything that I missed :grin: 