### PR TITLE
:lipstick: Customize Bulma variables with JB colors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,15 @@ Our base of operations for group discussions on this project: [Jupiter Web Site 
 ### How do I style my UI components?
 
 * Please try to use [Bulma](https://bulma.io/) as much as possible for all your frontend needs. It has a great documentation and is easy to grasp quickly. You can probably achieve everythin you need using the Bulma CSS classes.
-* If you end up not finding what you need there, or need to build somethin on top of Bulma, your CSS (technically SASS) would go into this [directory](themes/jb/assets/css). 
+* Try and use the color variables defined in [_variables.sass](./themes/jb/assets/css/_variables.sass)
+  * Some of the colors have multiple aliases for convineice 
+  * All of these colors have been set-up for use with [Bulma modifiers syntax](https://bulma.io/documentation/overview/modifiers/#docsNav), here are some examples:
+    ```
+    <button class="button is-primary">is-jb-pink</button>
+    <button class="button is-jb-pink">is-jb-pink</button>
+    <button class="button is-lup-blue">is-lup-blue</button>
+    ```
+* If you end up not finding what you need there, or need to build somethin on top of Bulma, your CSS (technically SASS) would go into this [directory](./themes/jb/assets/css). 
   * Please try and follow the existing structure as an example.
 
 ---

--- a/themes/jb/assets/css/_variables.sass
+++ b/themes/jb/assets/css/_variables.sass
@@ -1,35 +1,108 @@
-
-// Libs
+/*******************************************************************************
+ * Libs:
+ ******************************************************************************/
 @fa-font-path:   "/fonts"
 
-// Colors
-$white: #ffffff
-$bg-color: #232323
+// While Bulma has to be imported after this file in order to properly override
+// the its variables, the `findColorInvert` function is required here below.
+@import "libs/bulma/sass/utilities/functions"
 
-// grey
-$body-background-color: #222831
 
-// Backgrounds
-$dark-bg: #0a0b0c
-$dark-blue: #181C22
+/*******************************************************************************
+ * Custom Colors:
+ ******************************************************************************/
 
-// Fonts
+/*
+ * JB Brand Colors and Custom Colors:
+ ******************************************************************************/
+$jb-grey-dark: #2a2a2a // aka "DARK GRAY"
+$jb-grey: #6a6a6a // aka "COOL GRAY"
+$jb-grey-light: #cccccc // aka "SUBTLE GREY"
+$jb-orange: #ed7026 // aka "RED LEICESTER ORANGE"
+$jb-gold: #f5b821 // aka "BLOWFISH ORANGE"
+$jb-green: #00d900 // aka "CONSOLE GREEN"
+$jb-blue: #0070bd // aka "BOLD BLUE"
+$jb-blue-light: #6ecff5 // aka "CLOUD BLUE"
+$jb-pink: #d417a3 // aka "VDEV VIOLET"
+$jb-red: #d9001a // aka "ERROR RED"
+
+// These are all shades of blue
+$jb-dark: #222831
+$jb-darker: #181C22
+$jb-darkest: #0a0b0c
+
+
+/*
+ * JB Show Colors (current shows only):
+ ******************************************************************************/
+$ssh-orange: $jb-orange
+$lup-blue: $jb-blue
+$lup-blue-light: $jb-blue-light
+$lan-red: $jb-red
+$je-grey: $jb-grey-light
+$extras-grey: $je-grey // aliased, because "je" isn't a commonly known acronym
+
+
+/*
+ * This `$custom-colors` map allows using the string keys as a css class.
+ * For example:
+ *      <button class="button is-jb-pink">Orange</button>
+ *
+ * All the colors under this "Custom Colors" should be included in a similar
+ * fashion.
+ */  
+$custom-colors: ( "jb-grey-dark": ($jb-grey-dark, findColorInvert($jb-grey-dark)), "jb-grey": ($jb-grey, findColorInvert($jb-grey)), "jb-grey-light": ($jb-grey-light, findColorInvert($jb-grey-light)), "jb-orange": ($jb-orange, findColorInvert($jb-orange)), "jb-gold": ($jb-gold, findColorInvert($jb-gold)), "jb-green": ($jb-green, findColorInvert($jb-green)), "jb-blue": ($jb-blue, findColorInvert($jb-blue)), "jb-blue-light": ($jb-blue-light, findColorInvert($jb-blue-light)), "jb-pink": ($jb-pink, findColorInvert($jb-pink)), "jb-red": ($jb-red, findColorInvert($jb-red)), "ssh-orange": ($ssh-orange, findColorInvert($ssh-orange)), "lup-blue": ($lup-blue, findColorInvert($lup-blue)), "lup-blue-light": ($lup-blue-light, findColorInvert($lup-blue-light)), "lan-red": ($lan-red, findColorInvert($lan-red)), "je-grey": ($je-grey, findColorInvert($je-grey)), "extras-grey": ($extras-grey, findColorInvert($extras-grey)), "jb-dark": ($jb-dark, findColorInvert($jb-dark)), "jb-darker": ($jb-darker, findColorInvert($jb-darker)), "jb-darkest": ($jb-darkest, findColorInvert($jb-darkest)) );
+
+/*******************************************************************************
+ * Bulma Customizations:
+ * https://bulma.io/documentation/customize/variables/
+ ******************************************************************************/
+
+/* Some of Bulma's default "Initial Variables" (literals):
+ * (Those are here because we use them in this file - prior to importing Bulma)
+ ******************************************************************************/
+$white: hsl(0, 0%, 100%)
+
+
+/* Derived variables (calculated) - overrides:
+ ******************************************************************************/
+$primary: $jb-blue
+$link: $jb-blue
+$link-hover: $jb-blue-light
+$link-hover-border: $jb-blue-light
+$info: $jb-blue-light
+$success: $jb-green
+$warning: $jb-orange
+$danger: $jb-red
+
 $text: $white
 $text-strong: $white
-$white-dark: rgba(255,255,255,.7)
-$title-color: $white
 
-// Navbar
-$navbar-background-color: $dark-bg
-$navbar-breakpoint: 885px
+$background: $jb-grey
+$body-background-color: $jb-dark
 
-// Cards
-$card-background-color: $dark-blue
+/* Elements:
+ ******************************************************************************/
+
+/* Componenets:
+ ******************************************************************************/
+
+// Card
+$card-background-color: $jb-darker
 $card-content-background-color: $card-background-color
 $card-color: $white
 $card-header-color: $white
 $card-radius: 12px
 
+// Navbar
+$navbar-background-color: $jb-darkest
+$navbar-breakpoint: 885px
+
+/* Form:
+ ******************************************************************************/
+
+/* Layout:
+ ******************************************************************************/
+
 // Footer
-$footer-color: $white-dark
-$footer-background-color: $dark-bg
+$footer-background-color: $jb-darkest

--- a/themes/jb/assets/css/components/footer.sass
+++ b/themes/jb/assets/css/components/footer.sass
@@ -1,6 +1,6 @@
 .footer
   a
-    color: $white-dark
+    color: $grey-light
   a.active,
   a:hover
     color: $white

--- a/themes/jb/layouts/partials/episode/podverseplayer.html
+++ b/themes/jb/layouts/partials/episode/podverseplayer.html
@@ -8,36 +8,23 @@
 </div>
 
 <script>
-  // JupiterBroadcasting Branding colors:
-  const JBColorsRGB = {
-    // jb-brand, linux-unplugged, coder-radio
-    blueCloud: '#6ecff5',       
-    // jb-brand, linux-unplugged
-    blueBold: '#0070bd',
-    // jb-brand
-    grayDark: '#2a2a2a',        
-    // jb-brand
-    grayCool: '#6a6a6a',  
-    // jupiter-extras      
-    graySubtle: '#cccccc',
-    // coder-radio, linux-action-news, user-error
-    redError: '#d9001a',
-    // bsd-now, linux-headlines
-    orangeBlowfish: '#f5b821',
-    // choose-linux
-    greenConsole: '#00d900',   
-    // self-hosted
-    orangeRedLeicester: '#ed7026',
-    // tech-snap
-    violetVdev: '#d417a3'
+  // Colors matching the SASS colors in _variables.sass
+  const COLORS = {
+    white: '#ffffff',
+    darker: '#181C22',
+    blue: '#6ecff5',
+    blueDark: '#0070bd',
+    greyDark: '#2a2a2a',
+    grey: '#6a6a6a',
+    greyLight: '#cccccc',
   };
 
   /**
-  * See sample code:
-  *    https://github.com/podverse/podverse-web/blob/master/pages/embed/player-demo-custom-css.tsx
-  * Demo:
-  *    https://podverse.fm/embed/player-demo-custom-css
-  **/
+   * See sample code:
+   *    https://github.com/podverse/podverse-web/blob/master/pages/embed/player-demo-custom-css.tsx
+   * Demo:
+   *    https://podverse.fm/embed/player-demo-custom-css
+   **/
   let pvEmbedHasLoadedListener;
 
   function pvHandleCSSOverrides(e) {
@@ -58,24 +45,22 @@
       return;
     }
 
-
     const messageBody = {
       eventName: 'pv-embed-load-custom-css',
       styleRules: {
-        '--pv-embed-background-color': JBColorsRGB.grayDark,
-        '--pv-embed-border-color': JBColorsRGB.grayCool + '40', // 0x40 alpha = 25%
-        '--pv-embed-divider-color': 'green',
+        '--pv-embed-background-color': COLORS.darker,
+        '--pv-embed-border-color': COLORS.grey + '60', // 0x60 alpha = 37.5%
         '--pv-embed-font-family': 'BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif',
-        '--pv-embed-text-color-primary': '#fff',
-        '--pv-embed-text-color-secondary': JBColorsRGB.blueCloud,
-        '--pv-embed-text-color-tertiary': JBColorsRGB.graySubtle,
-        '--pv-embed-play-button-background-color': JBColorsRGB.blueBold,
-        '--pv-embed-play-button-border-color': JBColorsRGB.blueCloud,
-        '--pv-embed-play-button-icon-color': '#fff',
-        '--pv-embed-slider-background-color': JBColorsRGB.blueBold + '80', // 0x80 alpha = 50%
-        '--pv-embed-slider-fill-color': '#fff',
-        '--pv-embed-slider-marker-color': JBColorsRGB.blueCloud,
-        '--pv-embed-slider-highlight-color': JBColorsRGB.blueCloud + '40', // 0x40 alpha = 25%
+        '--pv-embed-text-color-primary': COLORS.white,
+        '--pv-embed-text-color-secondary': COLORS.blue,
+        '--pv-embed-text-color-tertiary': COLORS.greyLight,
+        '--pv-embed-play-button-background-color': COLORS.blueDark,
+        '--pv-embed-play-button-border-color': COLORS.blueDark,
+        '--pv-embed-play-button-icon-color': COLORS.white,
+        '--pv-embed-slider-background-color': COLORS.blueDark + '80', // 0x80 alpha = 50%
+        '--pv-embed-slider-fill-color': COLORS.white,
+        '--pv-embed-slider-marker-color': COLORS.blue,
+        '--pv-embed-slider-highlight-color': COLORS.blue + '40', // 0x40 alpha = 25%
       },
     };
 


### PR DESCRIPTION
Relates to #109

- [x] Organize _variables.sass file (lots of informative comments)
- [x] Create `$jb-*` SASS variables for JB Brand colors (grabbed from the shared PDF doc in matrix)
- [x] Use naming for color variables similar to Bulmas for consistency (e.g. with `-light`, `-lighter`, `-dark`, etc. suffixes)
- [x]  Create some aliases for same colors (based on show brands)
- [x] Add ability to use all the custom columns with the `is-*` [Bulma CSS class modifiers](https://bulma.io/documentation/overview/modifiers/#docsNav)
- [x] Override almost all (left out `$dark` to default) Bulma's [primary color variables](https://bulma.io/documentation/customize/variables/) with JB brand colors
- [x] Use the all the existing colors/shades when possible (use `$grey-light` instead of custom color for the links in the footer)
- [x] Change color of links during on-hover event to `$jb-blue-light` (from dark grey) 
- [x] Write documentation (a little note about this in contributing.md)


Below are the colors demonstrated using buttons. Each button's label is the CSS class that is set on that button, like so:
```
<button class="button is-jb-pink">is-jb-pink</button>
<button class="button is-lup-blue">is-lup-blue</button>
```

![Screenshot from 2022-07-21 00-54-43](https://user-images.githubusercontent.com/7744333/180136246-c433bad2-1731-435e-a6e1-2c08fea4b0ae.png)

As you can see many of these are the same, and serve as different aliases for convenience of use  :zap: