### PR TITLE
Issue #88 - Fixed Navbar Hover Background Color (white to dark grey)

### DIFF
--- a/themes/jb/assets/css/components/navbar.sass
+++ b/themes/jb/assets/css/components/navbar.sass
@@ -1,8 +1,14 @@
 @import "../libs/bulma/sass/utilities/mixins"
 
+$navbar-new-item-hover-color: $text !default
+$navbar-new-item-hover-background-color: $grey-dark !default
+
 $navbar-new-dropdown-background-color: $scheme-invert !default
-$navbar-new-dropdown-item-hover-color: $link !default
-$navbar-new-dropdown-item-hover-background-color: $scheme-main !default
+$navbar-new-dropdown-item-hover-color: $text !default
+$navbar-new-dropdown-item-hover-background-color: $grey-dark !default
+$navbar-dropdown-item-active-color: $text !default
+$navbar-dropdown-item-active-background-color: $background !default
+$navbar-new-dropdown-arrow: $text !default
 
 .navbar
   @each $name, $pair in $navbar-colors
@@ -54,6 +60,24 @@ $navbar-new-dropdown-item-hover-background-color: $scheme-main !default
               background-color: $color
               color: $color-invert
 
+.navbar-link:not(.is-arrowless)
+  +ltr-property("padding", 2.5em)
+  &::after
+    @extend %arrow
+    border-color: $navbar-new-dropdown-arrow
+    margin-top: -0.375em
+    +ltr-position(1.125em)
+
+a.navbar-item,
+.navbar-link
+  cursor: pointer
+  &:focus,
+  &:focus-within,
+  &:hover,
+  &.is-active
+    background-color: $navbar-new-item-hover-background-color
+    color: $navbar-new-item-hover-color
+
 +from($navbar-breakpoint)
   .navbar
     &.is-transparent
@@ -75,5 +99,5 @@ $navbar-new-dropdown-item-hover-background-color: $scheme-main !default
     &:hover,
     &.is-active
       .navbar-link
-        background-color: $navbar-item-hover-background-color
-        color: $link
+        background-color: $navbar-new-item-hover-background-color
+        color: $navbar-new-dropdown-item-hover-color


### PR DESCRIPTION
Fixed the background color for navbar items when you hover them from white to dark grey. Verified it works on mobile as well. 

This resolves the request from #114 