### PR TITLE
Move membership purchase links to top of page

### DIFF
--- a/content/membership/index.md
+++ b/content/membership/index.md
@@ -6,35 +6,8 @@ draft = false
 type=""
 +++
 
-## Support Jupiter Broadcasting 
+## Support Jupiter Broadcasting
 Your memberships keeps our production going and gives us the ability to run fewer ads and be picky about the ones we do run.
-
-
-
-### Special Features Available via Memberships
-#### [LINUX Unplugged]({{< ref "/show/linux-unplugged" >}})
-* The LINUX Unplugged Bootleg Stream
-	* The full live version of the show, which is often packed full of exclusive content. For that raw, no-edits, straight-to-tape, extended-recording feel.
-* Ad-free version
-
-#### [Self-Hosted]({{< ref "/show/self-hosted" >}})
-* The Self-Hosted Post Show
-* Ad-free version
-	
-#### [Coder Radio]({{< ref "/show/coder-radio" >}})
-* The Coderly Report
-* Ad-free version
-	
-#### [Linux Action News]({{< ref "/show/linux-action-news" >}})
-* Ad-free version
-	
-
-#### [Jupiter Extras]({{< ref "/show/jupiter-extras" >}}) 
-* Ad-free version
-
-	
-#### [Office Hours]({{< ref "/show/office-hours" >}})
-* Ad-free version
 
 ### Network Membership
 Access special features of every single show on the network, at a discount!
@@ -54,4 +27,27 @@ Access special features of an individual show only.
 ### Gift Memberships
 [Gift Memberships](https://jupitersignal.memberful.com/gift?plan=74364) are also available!
 
+### Special Features Available via Memberships
+#### [LINUX Unplugged]({{< ref "/show/linux-unplugged" >}})
+* The LINUX Unplugged Bootleg Stream
+	* The full live version of the show, which is often packed full of exclusive content. For that raw, no-edits, straight-to-tape, extended-recording feel.
+* Ad-free version
 
+#### [Self-Hosted]({{< ref "/show/self-hosted" >}})
+* The Self-Hosted Post Show
+* Ad-free version
+
+#### [Coder Radio]({{< ref "/show/coder-radio" >}})
+* The Coderly Report
+* Ad-free version
+
+#### [Linux Action News]({{< ref "/show/linux-action-news" >}})
+* Ad-free version
+
+
+#### [Jupiter Extras]({{< ref "/show/jupiter-extras" >}})
+* Ad-free version
+
+
+#### [Office Hours]({{< ref "/show/office-hours" >}})
+* Ad-free version


### PR DESCRIPTION
From Issue #148
- [x] move the "Network Membership", "Show Memberships" and "Gift Memberships" sections to be ABOVE the "Special Features" list.

The other task was moved to #164