### PR TITLE
Adding Dockerfile + Makefile dev workflow back

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,3 @@
-FROM ubuntu:jammy AS builder
-RUN apt-get update && apt-get install -y hugo
-WORKDIR /build
-COPY . .
-RUN hugo -D
-
-FROM nginx:1
-COPY --from=builder /build/public /usr/share/nginx/html
+FROM registry.gitlab.com/pages/hugo/hugo_extended:latest
+CMD [ "serve", "-D", "--bind", "0.0.0.0" ]
+ENTRYPOINT [ "hugo" ]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+SHELL := bash
+DOCKER_CHECK := $(shell command -v docker > /dev/null 2>&1 ; echo $$? )
+ifeq ($(DOCKER_CHECK), 0)
+BIN := docker
+else
+BIN := hugo
+endif
+
+ifeq ($(BIN), hugo)
+BIN_FLAGS := serve -D
+else
+BIN_FLAGS := container run --rm -it -v "$${PWD}":/app -w /app -p $${HOST_IP:-127.0.0.1}:1313:1313 jb_hugo:latest
+endif
+
+dev: deps
+	$(BIN) $(BIN_FLAGS)
+
+deps:
+	if [ "$(BIN)" == hugo ] ; then \
+		hugo version | grep 'extended' >/dev/null || (echo "You don't have the extended version of hugo, please install it" && exit 1); \
+	else \
+		docker build --rm -f Dockerfile -t jb_hugo:latest . ;\
+	fi


### PR DESCRIPTION
Based on [convo from matrix room](https://matrix.to/#/!rDlEtonuSythLzmxQL:jupiterbroadcasting.com/$2c6FJdVtXwSEHjO558mLR8DbfbZRsfOrTCsx7_Q4GDM?via=matrix.org&via=jupiterbroadcasting.com&via=0x6b.dev).

The Makefile will default to use docker (to help prevent environment issues), but will fallback to the hugo binary if docker isn't installed. It'll also check to make sure they have the extended version of hugo if using the hugo binary (since we're using SASS).

The one requirement would be that everyone has to be running some type of *nix (OSX should work as well, because I'm using really basic native commands for checking for different things). So, if they don't have that, they'll have to run the commands themself :upside_down_face: 

This is my first Makefile I've every written, so don't judge too harshly :grin: took a lot of inspiration from [this file](https://github.com/thechangelog/changelog.com/blob/9aa5f58418fe6feebeb6e8d2709e9dd5dd9cf70a/Makefile). I've heard @gerhard talk about using Makefiles while listening to @thechangelog's podcasts (mainly [Ship It](https://shipit.show)), so I figured I'd seek inspiration :sweat_smile: 