### PR TITLE
Fix #135 - Set proper color for notch area on iPhone

### DIFF
--- a/themes/jb/layouts/partials/meta.html
+++ b/themes/jb/layouts/partials/meta.html
@@ -73,6 +73,10 @@
 <link rel="icon" href="/favicons/favicon-32.png" sizes="32x32" />
 <link rel="icon" sizes="192x192" href="/favicons/favicon-192.png" />
 
+<!-- iPhone Notch Theme Color -->
+
+<meta name="theme-color" content="#0a0b0c">
+
 <!-- Search Engine Crawler -->
 
 <meta name="robots" content="index,follow" />


### PR DESCRIPTION
Fix for #135, sets the notch area on iOS the same color as the navbar.

**Before**
<img width="300" alt="after" src="https://user-images.githubusercontent.com/8635747/180667858-a4a22594-cb6d-4637-bd2f-d06edd98963d.png">

**After**
<img width="300" alt="after" src="https://user-images.githubusercontent.com/8635747/180667884-006e5b1b-6f5f-40c8-b8e3-52bb4ce70cec.png">