### PR TITLE
correct Telegram link

### DIFF
--- a/content/community/telegram.md
+++ b/content/community/telegram.md
@@ -6,5 +6,5 @@ date = "2022-07-19T20:59:07-04:00"
 draft = false
 logo = "https://upload.wikimedia.org/wikipedia/commons/8/82/Telegram_logo.svg"
 comms_type = "network"
-direct_link = "https://www.jupiterbroadcasting.com/telegram"
+direct_link = "https://t.me/jupitertelegram"
 +++


### PR DESCRIPTION
Telegram link was previously to jb.com/telegram which becomes a cirular link and problematic when this site goes live. Replaced w an absolute link to the destination https://t.me/jupitertelegram

closes #63 