### PR TITLE
Update hosts and links on show pages

### DIFF
--- a/themes/jb/layouts/partials/hosts/smallest.html
+++ b/themes/jb/layouts/partials/hosts/smallest.html
@@ -1,7 +1,9 @@
-
-<a href="/hosts/{{ .host.username }}" class="has-text-centered">
-  <figure class="image is-96x96">
-    <img src="{{ .host.avatar }}" alt="{{ .host.name }}" class="is-rounded"/>
-  </figure>
-  <strong>{{ .host.name }}</strong>
-</a>
+<div class="has-text-centered">
+  <a href="/hosts/{{ .host.username }}">
+    <figure class="image is-96x96" style="margin: 0 auto">
+    <!-- <figure class="image is-96x96 my-0 mx-auto"> -->
+      <img src="{{ .host.avatar }}" alt="{{ .host.name }}" class="is-rounded" />
+    </figure>
+    <strong>{{ .host.name }}</strong>
+  </a>
+</div>

--- a/themes/jb/layouts/partials/show/links.html
+++ b/themes/jb/layouts/partials/show/links.html
@@ -1,28 +1,24 @@
-  <div class="is-flex is-flex-direction-row is-justify-content-space-evenly">
-
+<div class="level">
   {{ range $key, $value := . }}
-      <div class="has-text-centered">
-
-      <a class="link" href="{{$value.url}}" title="{{$key}}">
-        {{ if eq  $key "email" }}
-          <div class="title fa fa-envelope fa-3x center" ><span class="sr-only">{{$key}}</span></div>
-        {{ else if eq $key "shownotes" }}
-          <div class="title fa fa-pencil-square fa-3x"><span class="sr-only">{{$key}}</span></div>
-        {{ else if eq $key "matrix" }}
-          <div class="title fa fa-matrix-org fa-3x"><span class="sr-only">{{$key}}</span></div>
-        {{ else if eq $key "mumble" }}
-          <div class="title fa fa-headphones fa-3x"><span class="sr-only">{{$key}}</span></div>
-        {{ else if eq $key "discord" }}
-          <div class="title fa fa-{{$key}} fa-3x"><span class="sr-only">{{$key}}</span></div>
-        {{ else if eq $key "wiki" }}
-          <div class="title fa fa-{{$key}}data fa-3x"><span class="sr-only">{{$key}}</span></div>
-        {{ else if eq $key "blog" }}
-          <div class="title fa fa-paragraph fa-3x"><span class="sr-only">{{$key}}</span></div>
-        {{ else }}
-          <div class="title fa fa-{{$key}}-square fa-3x"><span class="sr-only">{{$key}}</span></div>
-        {{ end }}
-      </a>
-    </div>
+    <a class="link level-item pr-3" href="{{$value.url}}" title="{{$key}}">
+      {{ if eq $key "email" }}
+        <div class="title fa fa-envelope fa-3x center"><span class="sr-only">{{$key}}</span></div>
+      {{ else if eq $key "shownotes" }}
+        <div class="title fa fa-pencil-square fa-3x"><span class="sr-only">{{$key}}</span></div>
+      {{ else if eq $key "matrix" }}
+        <div class="title fa fa-matrix-org fa-3x"><span class="sr-only">{{$key}}</span></div>
+      {{ else if eq $key "mumble" }}
+        <div class="title fa fa-headphones fa-3x"><span class="sr-only">{{$key}}</span></div>
+      {{ else if eq $key "discord" }}
+        <div class="title fa fa-{{$key}} fa-3x"><span class="sr-only">{{$key}}</span></div>
+      {{ else if eq $key "wiki" }}
+        <div class="title fa fa-{{$key}}data fa-3x"><span class="sr-only">{{$key}}</span></div>
+      {{ else if eq $key "blog" }}
+        <div class="title fa fa-paragraph fa-3x"><span class="sr-only">{{$key}}</span></div>
+      {{ else }}
+        <div class="title fa fa-{{$key}}-square fa-3x"><span class="sr-only">{{$key}}</span></div>
+    {{ end }}
+  </a>
   {{ end }}
 
-  </div>
+</div>

--- a/themes/jb/layouts/show/list.html
+++ b/themes/jb/layouts/show/list.html
@@ -12,11 +12,11 @@
         {{end}}
       </div>
       <div class="column is-half">
-        <h2 class="subtitle has-text-centered">Your Hosts</h2>
-        <div class="is-flex is-flex-direction-row is-justify-content-space-evenly">
+        <h2 class="subtitle has-text-centered-mobile">Your Hosts</h2>
+        <div class="columns is-multiline">
         {{ range $index, $hostname := .Params.hosts }}
           {{ $host := index $.Site.Data.people $hostname }}
-            <div class="has-text-centered">
+            <div class="column is-narrow">
               {{ partial "hosts/smallest.html" (dict "context" . "host" $host) }}
             </div>
         {{ end }}


### PR DESCRIPTION
Update to #87 the following enhancements have been made:

* Hosts
  * If the host name is *longer* than 96px, the image centers over the name (Mike and Alex are a good reference)
  * If the host name is *shorter* than 96px, the host's name is centered under the image (Wes and Allan are a good reference)
  * Hosts are dynamically moved to a new row when needed (Jupiter Extra's page shows this well)
  * "Your Hosts" title for the section moves to center in the mobile view

* Links
  * links are evenly spaced and aligned left instead of stretching across the bottom of the description

Here is a screenshot to show off some of the new enhancements.
![image](https://user-images.githubusercontent.com/34293941/181250491-96a37931-0577-4b2c-ae7c-254b68d78eac.png)