### PR TITLE
correct SSH Discord link

### DIFF
--- a/content/community/ssh-discord.md
+++ b/content/community/ssh-discord.md
@@ -5,5 +5,5 @@ date = "2022-07-19T20:59:07-04:00"
 draft = false
 logo = "/images/3rd-party/DiscordLogo.svg"
 comms_type = "Self-Hosted"
-direct_link = "https://selfhosted.show/discord"
+direct_link = "https://discord.com/invite/n49fgkp"
 +++


### PR DESCRIPTION
SSH Discord link was previously to https://selfhosted.show/discord which becomes a potential problem if/when selfhosted.show ever changes. Replaced w an absolute link to the destination https://discord.com/invite/n49fgkp