### PR TITLE
Additional links for Extras and Office Hours page templates

### DIFF
--- a/content/show/jupiter-extras/_index.md
+++ b/content/show/jupiter-extras/_index.md
@@ -16,6 +16,12 @@ support_link = "https://jupitersignal.memberful.com/checkout?plan=53334"
 
 podverse_podcast_id = "0vaTwihG1R"
 
+[links.shownotes]
+  url="https://extras.show"
+
+[links.email]
+  url="https://extras.show/contact"
+
 [links.twitter]
   url="https://twitter.com/jupiterextras"
 

--- a/content/show/office-hours/_index.md
+++ b/content/show/office-hours/_index.md
@@ -16,6 +16,12 @@ support_link = "https://jupitersignal.memberful.com/checkout?plan=53334"
 
 podverse_podcast_id = "GLuztlxs0-"
 
+[links.shownotes]
+  url="https://www.officehours.hair/"
+
+[links.email]
+  url="https://www.officehours.hair/contact"
+
 [links.twitter]
   url="https://twitter.com/ChrisLAS"
 


### PR DESCRIPTION
fixes #185 

Used `https://www.officehours.hair/contact` based on the assumption that #184  would follow the same pattern as other  shows for contact forms on fireside. 