### PR TITLE
:lipstick: Change text-color of markdown inline code

### DIFF
--- a/themes/jb/assets/css/_variables.sass
+++ b/themes/jb/assets/css/_variables.sass
@@ -78,6 +78,8 @@ $danger: $jb-red
 $text: $white
 $text-strong: $white
 
+$code: $white
+
 $background: $jb-grey
 $body-background-color: $jb-dark
 


### PR DESCRIPTION
I noticed that the color of the inline `markdown code` is not very legible, so I changed it to white:

**Before:**
![Screenshot from 2022-07-30 13-22-04](https://user-images.githubusercontent.com/7744333/181934747-fbfcfff1-f98c-4cd2-adbd-fba28d89be76.png)

**After:**
![image](https://user-images.githubusercontent.com/7744333/181934725-a10cf0f3-4914-4df8-ab40-850ddfaa64f1.png)
