### PR TITLE
Feature/support button

### DIFF
--- a/themes/jb/assets/css/_variables.sass
+++ b/themes/jb/assets/css/_variables.sass
@@ -71,7 +71,7 @@ $link: $jb-blue
 $link-hover: $jb-blue-light
 $link-hover-border: $jb-blue-light
 $info: $jb-blue-light
-$success: $jb-green
+// $success: $jb-green
 $warning: $jb-orange
 $danger: $jb-red
 

--- a/themes/jb/layouts/partials/episode/support.html
+++ b/themes/jb/layouts/partials/episode/support.html
@@ -1,2 +1,2 @@
 
-<a href="{{.CurrentSection.Params.support_link}}" class="button is-success">Support {{.CurrentSection.Title}}</a>
+<a href="{{.CurrentSection.Params.support_link}}" class="button is-info">Support {{.CurrentSection.Title}}</a>


### PR DESCRIPTION
Closes #159 

- This reverts the `success` Bulma color to the Bulma's default (`hsl(153, 53%, 53%)`); and
- Uses `info` color (the light blue of JB) for the the support button instead of the `success` color to match the rest of the site's style

![Screenshot from 2022-07-30 13-35-10](https://user-images.githubusercontent.com/7744333/181935264-f32c640f-a303-44c9-8705-c0f2206411ed.png)

