### PR TITLE
Infra/build improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM registry.gitlab.com/pages/hugo/hugo_extended:latest
+FROM klakegg/hugo:0.101.0-ext-alpine
 CMD [ "serve", "-D", "--bind", "0.0.0.0" ]
 ENTRYPOINT [ "hugo" ]

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,3 @@
-SHELL := bash
-DOCKER_CHECK := $(shell command -v docker > /dev/null 2>&1 ; echo $$? )
-ifeq ($(DOCKER_CHECK), 0)
-BIN := docker
-else
-BIN := hugo
-endif
-
-ifeq ($(BIN), hugo)
-BIN_FLAGS := serve -D
-else
-BIN_FLAGS := container run --rm -it -v "$${PWD}":/app -w /app -p $${HOST_IP:-127.0.0.1}:1313:1313 jb_hugo:latest
-endif
-
-dev: deps
-	$(BIN) $(BIN_FLAGS)
-
-deps:
-	if [ "$(BIN)" == hugo ] ; then \
-		hugo version | grep 'extended' >/dev/null || (echo "You don't have the extended version of hugo, please install it" && exit 1); \
-	else \
-		docker build --rm -f Dockerfile -t jb_hugo:latest . ;\
-	fi
+dev:
+	docker build --rm -f Dockerfile -t jb_hugo:latest .
+	docker run --rm -it -v "$${PWD}":/app -w /app -p $${HOST_IP:-127.0.0.1}:1313:1313 jb_hugo:latest

--- a/README.md
+++ b/README.md
@@ -24,41 +24,15 @@ Built with Hugo and deployed with Github Actions
 
 Demo: https://jupiterbroadcasting.net
 
-### Setup
+### Development Environment Setup
 
-#### Using Hugo binary
-You must install  the Hugo Extended Sass/SCSS version.
+The site is deployed to production as a container and therefore we recommend development is done using docker. A convenient command in the makefile is provided to help you get started. If you're new to docker [start here](https://docs.docker.com/get-docker/).
 
-Install Hugo: https://gohugo.io/getting-started/installing/
+To build and run the site run
 
-Hugo Extended Linux binary: https://github.com/gohugoio/hugo/releases
+    make dev
 
-Start the development Server (rebuilds on every filesystem change)
-
-`hugo server -D`
-
-#### Using Docker
-
-To build and run the docker image:
-`make dev`
-
-#### run for different Site
-
-`hugo server -D --config config.coderradio.toml`
-
-to clean the module config
-
-`hugo mod clean --all`
-
-build
-
-`hugo -D --config config.coderradio.toml`
-
-Hugo issue currently regarding overlapping mounts
-
-https://github.com/gohugoio/hugo/issues/7123
-
-so for now only subdirectories work
+This will build the site (all 28000+ pages) and takes anywhere from 30s - 5 minutes depending on your hardware. This is expected due to the size of the site.
 
 #### Deployment
 


### PR DESCRIPTION
Removed all the logic from the makefile pertaining to logic binaries of hugo. The production site will be deployed as a container so it makes more sense to build and develop the site in the same environment.