### PR TITLE
Update Episode cards

### DIFF
--- a/themes/jb/layouts/episode/single.html
+++ b/themes/jb/layouts/episode/single.html
@@ -45,7 +45,7 @@
             <h2>Hosts</h2>
             <section class="section host-list">
               <div class="container">
-                 <div class="columns is-multiline">
+                <div class="columns is-multiline">
                   {{ range $index, $hostname := .Params.hosts }}
                     {{ $host := index $.Site.Data.people $hostname }}
                       <div class="column is-6 is-4-fullhd is-4-desktop is-12-mobile"  style="display: flex;">

--- a/themes/jb/layouts/partials/episode/preview.html
+++ b/themes/jb/layouts/partials/episode/preview.html
@@ -1,23 +1,21 @@
-
 <div class="card card-episode">
-
-  <div class="card-image">
-    <figure class="image">
-      <a href="{{ .Permalink }}">
-        <img src="{{.Params.header_image }}" width="432" height="242" alt="{{.Title}} | {{.CurrentSection.Title}} {{.Params.episode}}">
-      </a>
-    </figure>
-  </div>
-  <div class="card-content">
-     <div class="content">
-      <a href="{{ .Permalink }}"><h3>{{.Title}}
-        {{ if ne .Title (print .CurrentSection.Title " " .Params.episode) }} 
-          | {{.CurrentSection.Title}} {{.Params.episode}}
-        {{ end }}
-      </h3></a>
-      <strong>{{ .Date.Day }}  {{ .Date.Month }} {{ .Date.Year }}</strong><br/>
-      <p>{{.Description}}</p>
+  <a href="{{ .Permalink }}">
+    <div class="card-image">
+      <figure class="image">
+        <img src="{{.Params.header_image }}" width="432" height="242"
+          alt="{{.Title}} | {{.CurrentSection.Title}} {{.Params.episode}}">
+      </figure>
+    </div>
+    <div class="card-content">
+      <div class="content">
+        <h3>{{.Title}}
+          {{ if ne .Title (print .CurrentSection.Title " " .Params.episode) }}
+            | {{.CurrentSection.Title}} {{.Params.episode}}
+          {{ end }}
+        </h3>
+        <strong>{{ .Date.Day }} {{ .Date.Month }} {{ .Date.Year }}</strong><br />
+        <p style="color:white">{{.Description}}</p>
       </div>
-  </div>
-
+    </div>
+  </a>
 </div>


### PR DESCRIPTION
Closes #247

* Clicking anywhere on the episode card will take you to the episode page instead of only the title and image. This creates consistent behavior with host and guest cards.