### PR TITLE
Retrieve Live or Latest PeerTube Episode

### DIFF
--- a/docs/page-specific-js.md
+++ b/docs/page-specific-js.md
@@ -1,0 +1,43 @@
+# How to Add JS for a Page
+1. Make JS
+2. Add a Hugo variable
+3. Import script with Hugo variable
+4. ...
+5. Debug!
+
+## Make JS
+You'll need to modify the theme that's applied to the markdown that Hugo processes in order to add new JS to any pages. First, ask yourself if __everyone__ needs to have this or if it can be added in a partial.
+
+### Ading to a Partial
+1. Add your fancy new JS in a file, `fancy.js` in `themes/jb/assets/js`
+2. Go find whichever partial your code belongs to, `fancy.html`
+3. Add a Hugo reference to the HTML
+    ``` go
+    {{ $fancy := resources.Get "js/fancy.js" }}
+    ```
+4. Add a `script` tag for the processed JS
+    ``` html
+    <script src="{{ $fancy.PermaLink }}"></script>
+    ```
+5. Call your function
+    - You probably know how to do this best!
+    ```html
+    // Example call for async function
+    <script>
+        window.onload = () => {
+            /**
+             * When window loads, call async function. Attach a callback
+             * to the Promise resolving, `.then(...)`, and rejecting,
+             * `.catch(...)`.
+             */
+            fancy()
+                .then(result => document.getElementById('targetId))
+                .catch(error => console.error(error), '')
+        }
+    </script>
+    ```
+
+### Adding to Main
+1. Add a function to `themes/jb/assets/js/main.js`
+2. Call your function
+    - See [above](###adding-to-a-partial), point 5

--- a/themes/jb/assets/js/jb-live.js
+++ b/themes/jb/assets/js/jb-live.js
@@ -1,0 +1,41 @@
+const JoopTubeURL = new URL("https://jupiter.tube/api/v1/")
+// This query shouldn't be merged to main, it's very dirty. Almost naughty, not ready for the big leagues
+const JoopTubeQuery = 
+({isLive}) => new URL("video-channels/live/videos?" +
+        `isLive=${isLive ? true : false}` + // Normally redundant, avoids injection
+        `&skipCount=false` +
+        `&count=1` +
+        `&sort=-createdAt`,
+    JoopTubeURL)
+
+async function jbLive() {
+    const headers = new Headers({
+        "Accept": "application/json"
+    });
+
+    const requestOptions = {
+        method: 'GET',
+        headers: headers,
+        redirect: 'follow'
+    };
+
+    const liveShowQuery = fetch(JoopTubeQuery({isLive: true}), requestOptions)
+        .then(response => response.text())
+        .then(result => JSON.parse(result))
+        //.then(result => result.value)
+        .catch(error => console.error('Error while fetching live URL!', error));
+    
+    const archivedShowQuery = fetch(JoopTubeQuery({isLive: false}), requestOptions)
+        .then(response => response.text())
+        .then(result => JSON.parse(result))
+        .catch(error => console.error(('Error while fetching live URL!', error)))
+
+    const getEmbedLink = show => {
+        const embedPath = show?.value?.data?.[0]?.embedPath
+        return !embedPath ? undefined : new URL(embedPath, JoopTubeURL);
+    }
+
+    const [liveShow, archivedShow] = await Promise.allSettled([liveShowQuery, archivedShowQuery])
+
+    return getEmbedLink(liveShow).toString() ?? getEmbedLink(archivedShow).toString()
+}

--- a/themes/jb/assets/js/jb-live.js
+++ b/themes/jb/assets/js/jb-live.js
@@ -1,13 +1,44 @@
-const JoopTubeURL = new URL("https://jupiter.tube/api/v1/")
-// This query shouldn't be merged to main, it's very dirty. Almost naughty, not ready for the big leagues
-const JoopTubeQuery = 
-({isLive}) => new URL("video-channels/live/videos?" +
+/* Query URLs */
+const JoopTubeURL = new URL("https://jupiter.tube/api/v1/");
+const JoopTubeQuery =
+    ({ isLive }) => new URL("video-channels/live/videos?" +
         `isLive=${isLive ? true : false}` + // Normally redundant, avoids injection
         `&skipCount=false` +
         `&count=1` +
         `&sort=-createdAt`,
-    JoopTubeURL)
+        JoopTubeURL);
 
+/**
+ * Gets the embedable link from a PeerTube Video object passed via Promise
+ * 
+ * This assumes the result of the promise of is an API repsonse
+ *      with at least one result. If no shows are live the API response
+ *      will be undefined at `promiseResult.value`, don't poke it.
+ * 
+ * @param {PromiseSettledResult<Response>} show The final result of either fetch call above
+ * @returns {URL | undefined} The URL object referencing the embedable video
+ */
+const getEmbedLink = show => {
+    if (!show || show.status === 'rejected') {
+        return undefined
+    }
+
+    const promiseResult = show.value
+    /**
+     * @const 
+     * @type {string | undefined}
+     */
+    const embedPath = promiseResult.data?.[0]?.embedPath;
+    return !embedPath ? undefined : new URL(embedPath, JoopTubeURL);
+};
+
+/**
+ * Queries the 'live' channel at jupiter.tube for either
+ *      a) the embed link of the currently live show
+ *      OR
+ *      b) the embed link of the most recently aired show
+ * @returns {string} The embedable URL
+ */
 async function jbLive() {
     const headers = new Headers({
         "Accept": "application/json"
@@ -19,23 +50,17 @@ async function jbLive() {
         redirect: 'follow'
     };
 
-    const liveShowQuery = fetch(JoopTubeQuery({isLive: true}), requestOptions)
+    const liveShowQuery = fetch(JoopTubeQuery({ isLive: true }), requestOptions)
         .then(response => response.text())
         .then(result => JSON.parse(result))
-        //.then(result => result.value)
         .catch(error => console.error('Error while fetching live URL!', error));
-    
-    const archivedShowQuery = fetch(JoopTubeQuery({isLive: false}), requestOptions)
+
+    const archivedShowQuery = fetch(JoopTubeQuery({ isLive: false }), requestOptions)
         .then(response => response.text())
         .then(result => JSON.parse(result))
-        .catch(error => console.error(('Error while fetching live URL!', error)))
-
-    const getEmbedLink = show => {
-        const embedPath = show?.value?.data?.[0]?.embedPath
-        return !embedPath ? undefined : new URL(embedPath, JoopTubeURL);
-    }
+        .catch(error => console.error(('Error while fetching live URL!', error)));
 
     const [liveShow, archivedShow] = await Promise.allSettled([liveShowQuery, archivedShowQuery])
 
-    return getEmbedLink(liveShow).toString() ?? getEmbedLink(archivedShow).toString()
+    return getEmbedLink(liveShow)?.toString() ?? getEmbedLink(archivedShow)?.toString();
 }

--- a/themes/jb/layouts/partials/live/jb-tube.html
+++ b/themes/jb/layouts/partials/live/jb-tube.html
@@ -1,0 +1,14 @@
+<div class="jb-tube-wrapper">
+  <div class="jb-tube">
+    <div class="jb-tube-video">
+      <iframe
+        title="jblive.tv Stream"
+        src="https://jupiter.tube/videos/embed/dbec0720-5daa-4b1f-a4c1-553ad625d0f6?warningTitle=0"
+        allowfullscreen=""
+        sandbox="allow-same-origin allow-scripts allow-popups"
+        width="560"
+        height="315"
+        frameborder="0"></iframe>
+    </div>
+  </div>
+</div>

--- a/themes/jb/layouts/partials/live/jb-tube.html
+++ b/themes/jb/layouts/partials/live/jb-tube.html
@@ -8,7 +8,7 @@
   {{ $jbTube := resources.Get "js/jb-live.js" }}
   <script src="{{ $jbTube.Permalink }}"></script>
   <script>
-    window.onload = function () {
+    window.onload = () => {
       jbLive().then(result => document.getElementById('liveStream').src = result);
     }
   </script>

--- a/themes/jb/layouts/partials/live/jb-tube.html
+++ b/themes/jb/layouts/partials/live/jb-tube.html
@@ -1,8 +1,8 @@
 <div class="jb-tube-wrapper">
-  <div class="jb-tube">
+  <div class="jb-tube" style="text-align: center;">
     <div class="jb-tube-video">
-      <iframe id="liveStream" title="jblive.tv Stream" src=jbLive() allowfullscreen=""
-        sandbox="allow-same-origin allow-scripts allow-popups" width="560" height="315" frameborder="0"></iframe>
+      <iframe id="liveStream" title="jblive.tv Stream" src="" allowfullscreen=""
+        sandbox="allow-same-origin allow-scripts allow-popups" width="650" height="366" frameborder="0"></iframe>
     </div>
   </div>
   {{ $jbTube := resources.Get "js/jb-live.js" }}

--- a/themes/jb/layouts/partials/live/jb-tube.html
+++ b/themes/jb/layouts/partials/live/jb-tube.html
@@ -1,14 +1,15 @@
 <div class="jb-tube-wrapper">
   <div class="jb-tube">
     <div class="jb-tube-video">
-      <iframe
-        title="jblive.tv Stream"
-        src="https://jupiter.tube/videos/embed/dbec0720-5daa-4b1f-a4c1-553ad625d0f6?warningTitle=0"
-        allowfullscreen=""
-        sandbox="allow-same-origin allow-scripts allow-popups"
-        width="560"
-        height="315"
-        frameborder="0"></iframe>
+      <iframe id="liveStream" title="jblive.tv Stream" src=jbLive() allowfullscreen=""
+        sandbox="allow-same-origin allow-scripts allow-popups" width="560" height="315" frameborder="0"></iframe>
     </div>
   </div>
+  {{ $jbTube := resources.Get "js/jb-live.js" }}
+  <script src="{{ $jbTube.Permalink }}"></script>
+  <script>
+    window.onload = function () {
+      jbLive().then(result => document.getElementById('liveStream').src = result);
+    }
+  </script>
 </div>

--- a/themes/jb/layouts/partials/live/twitch.html
+++ b/themes/jb/layouts/partials/live/twitch.html
@@ -1,7 +1,0 @@
-<div class="twitch-wrapper">
-  <div class="twitch">
-    <div class="twitch-video">
-    <iframe title="Self-Hosted 77 Live - Another Man's Assistant" width="560" height="315" src="https://jupiter.tube/videos/embed/46a0e520-9aa8-408d-b815-ec06173da8ac?warningTitle=0" frameborder="0" allowfullscreen="" sandbox="allow-same-origin allow-scripts allow-popups"></iframe>
-    </div>
-  </div>
-</div>

--- a/themes/jblive/layouts/index.html
+++ b/themes/jblive/layouts/index.html
@@ -2,7 +2,7 @@
   {{.Content}}
 
     <div class="container">
-      {{ partial "live/twitch.html" . }}
+      {{ partial "live/jb-tube.html" . }}
     </div>
     <div class="container">
       {{ partial "live/links.html" . }}


### PR DESCRIPTION
### Todo
- [x] Query for the live embed link
- [x] Remove Twitch references
- [x] Call JS from the Live page
  - [x] Automatically update the embed url 🤖 
- [ ] Exclude scheduled episodes from results, or is this a feature 🤔 ?
- [x] Make iframe beauteous
  - [x] Center
  - [x] Embiggen
- [x] Docs
  - [x] jsdocs
  - [x] How to add page specific js

### Testing
- [x] macOS
  - [x] Safari
  - [x] Firefox
- [ ] *nix
  - [ ] NixOS
    - [ ] Gnome Web
    - [ ] Firefox

#122 