### PR TITLE
Feature/responsive navbar and brand

### DIFF
--- a/themes/jb/assets/css/_variables.sass
+++ b/themes/jb/assets/css/_variables.sass
@@ -98,7 +98,7 @@ $card-radius: 12px
 
 // Navbar
 $navbar-background-color: $jb-darkest
-$navbar-breakpoint: 885px
+$navbar-breakpoint: 1220px
 
 /* Form:
  ******************************************************************************/

--- a/themes/jb/layouts/partials/header.html
+++ b/themes/jb/layouts/partials/header.html
@@ -2,6 +2,12 @@
   <nav class="navbar is-fixed-top {{ if eq .Params.hashero false  }}gradient-home{{end}}" id="mainnavigation" role="navigation" aria-label="main navigation">
       <div class="container">
           <div class="navbar-brand">
+            {{ range (where .Site.Menus.main "Identifier" "home")}}
+                <a href="{{ .URL }}" class="navbar-item">
+                    {{ .Pre }}
+                    <span>{{ .Name }}</span>
+                </a>
+            {{ end }}
               <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false"
                  data-target="navbarBasicExample">
                   <span aria-hidden="true"></span>
@@ -54,6 +60,8 @@
                               {{ end }}
                           </div>
                       </div>
+                      {{ else if eq .Identifier "home"}}
+                      <!-- do nothing, home is done as "navbar-brand" class above outside of "navbar-menu" -->
                       {{ else }}
                           <a href="{{ .URL }}" {{ if (hasPrefix .Identifier "ext-") }}target="_blank"{{ end }} class="navbar-item {{ if $active }}active{{ end }}">
                               {{ .Pre }}


### PR DESCRIPTION
Related to #171 

- It fixes it with the most basic solution of increasing the breakpoint when the navbar menu items collapse into the hamburger menu
- Also moves the brand logo move outside of the regular menu items ([see this for more info](https://bulma.io/documentation/components/navbar)) - and essentially now the brand logo is always there, even during the hamburger menu