### PR TITLE
Configure shows-slider to slide more than once show at a time

### DIFF
--- a/themes/jb/assets/js/main.js
+++ b/themes/jb/assets/js/main.js
@@ -3,34 +3,43 @@ const swiper = new Swiper(".show-slider", {
       nextEl: '.swiper-button-next',
       prevEl: '.swiper-button-prev',
     },
+    slidesPerGroup: 1,
     slidesPerView: 1.1,
     spaceBetween: 12,
     // Responsive breakpoint
     breakpoints: {
     // when window width is >= 480px
     440: {
-      slidesPerView: 1.3
+      slidesPerView: 1.3,
+      slidesPerGroup: 1
     },
     600: {
-      slidesPerView: 1.7
+      slidesPerView: 1.7,
+      slidesPerGroup: 1
     },
     640: {
-      slidesPerView: 2.1
+      slidesPerView: 2.1,
+      slidesPerGroup: 2
     },
     850: {
-      slidesPerView: 2.7
+      slidesPerView: 2.7,
+      slidesPerGroup: 2
     },
     1000: {
-      slidesPerView: 3.1
+      slidesPerView: 3.1,
+      slidesPerGroup: 3
     },
     1216: {
-      slidesPerView: 3.7
+      slidesPerView: 3.7,
+      slidesPerGroup: 3
     },
     1450: {
-      slidesPerView: 4.1
+      slidesPerView: 4.1,
+      slidesPerGroup: 4
     },
     1550: {
-        slidesPerView: 4.3
+        slidesPerView: 4.3,
+        slidesPerGroup: 4
     }
   }
   });


### PR DESCRIPTION
When next/prev button is pressed, the whole view will slide to the next list of shows that weren't visible before (changes with breakpoints)
IMO it's a little bit more intuitive this way