### PR TITLE
Infra/automated deployment

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,33 @@
+name: Deploy to VPS
+
+on:
+  push:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+           
+      # Build
+      - name: Pull latest changes on VPS
+        uses: appleboy/ssh-action@master
+        with:
+            host: ${{ secrets.VPS_HOST }}
+            USERNAME: ${{ secrets.VPS_DEPLOY_USER }}
+            PORT: ${{ secrets.VPS_SSH_PORT }}
+            KEY: ${{ secrets.VPS_SSHKEY }}
+            script: cd ${{ secrets.VPS_PROJECT_PATH }} && git fetch && git pull
+            
+      - name: Deploy
+        uses: appleboy/ssh-action@master
+        with:
+            host: ${{ secrets.VPS_HOST }}
+            USERNAME: ${{ secrets.VPS_DEPLOY_USER }}
+            PORT: ${{ secrets.VPS_SSH_PORT }}
+            KEY: ${{ secrets.VPS_SSHKEY }}
+            script: cd ${{ secrets.VPS_PROJECT_PATH }} && make deploy-prod

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM registry.gitlab.com/pages/hugo/hugo_extended:0.101.0 as builder
-RUN mkdir -p /app
-WORKDIR /app
-COPY . /app
+RUN mkdir -p /site
+WORKDIR /site
+COPY . /site
 RUN hugo
 
 FROM nginx
 RUN rm -rf /usr/share/nginx/html/*
-COPY --from=builder /app/public /usr/share/nginx/html
+COPY --from=builder /site/public /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ WORKDIR /site
 COPY . /site
 RUN hugo
 
-FROM nginx
+FROM nginx:alpine
 RUN rm -rf /usr/share/nginx/html/*
 COPY --from=builder /site/public /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,9 @@
-FROM registry.gitlab.com/pages/hugo/hugo_extended:0.101.0
-CMD [ "serve", "-D", "--bind", "0.0.0.0" ]
-ENTRYPOINT [ "hugo" ]
+FROM registry.gitlab.com/pages/hugo/hugo_extended:0.101.0 as builder
+RUN mkdir -p /app
+WORKDIR /app
+COPY . /app
+RUN hugo
+
+FROM nginx
+RUN rm -rf /usr/share/nginx/html/*
+COPY --from=builder /app/public /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM registry.gitlab.com/pages/hugo/hugo_extended:0.101.0 as builder
-RUN mkdir -p /site
 WORKDIR /site
 COPY . /site
 RUN hugo

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
 dev:
 	docker build --rm -f Dockerfile -t jb_hugo:latest .
 	docker run --rm -it -v "$${PWD}":/app -w /app -p $${HOST_IP:-127.0.0.1}:1313:1313 jb_hugo:latest
+
+deploy-prod:
+	docker build -t jb-jbcom .
+	docker-compose -f ~/docker-compose.yml up -d jb-jbcom
+	docker image prune -af


### PR DESCRIPTION
DO NOT MERGE YET

Laying the groundwork for automated production deployments. Comments on methodology welcomed.

The Hugo project does not recommend using the `hugo server` command in production stating that nginx or caddy is their preferred option for these types of deployments. Therefore the Dockerfile was updated to a multi-stage build dropping the usage of the less secure `hugo server -D` command. 

The website, once built in `/site/public` in the build stage, is copied in the nginx container and then docker-compose is used on the production VPS instance to auto detect changes and restart the container only if necessary.

Multi-stage builds mean that the build happens in a separate container (more secure) and the site remains live for as long as possible. Down the road this will also make automatic PR smoke testing more modular and easier to perform.