### PR TITLE
updates hugo url to new JB site

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = 'https://jupiterbroadcasting.net/'
+baseURL = 'https://new.jupiterbroadcasting.com/'
 languageCode = 'en-us'
 title = 'Jupiter Broadcasting'
 


### PR DESCRIPTION
migrates from now defunct jupiterbroadcasting.net URL to new.jupiterbroadcasting.com