### PR TITLE
Increase live peertube embed size.

### DIFF
--- a/themes/jb/layouts/partials/live/jb-tube.html
+++ b/themes/jb/layouts/partials/live/jb-tube.html
@@ -2,7 +2,7 @@
   <div class="jb-tube" style="text-align: center;">
     <div class="jb-tube-video">
       <iframe id="liveStream" title="jblive.tv Stream" src="" allowfullscreen=""
-        sandbox="allow-same-origin allow-scripts allow-popups" width="650" height="366" frameborder="0"></iframe>
+        sandbox="allow-same-origin allow-scripts allow-popups" width="960" height="540" frameborder="0"></iframe>
     </div>
   </div>
   {{ $jbTube := resources.Get "js/jb-live.js" }}


### PR DESCRIPTION
Bump live iframe size from 650x366 to 960x540.

Closes #281. 