### PR TITLE
making jb-live more responsive

### DIFF
--- a/themes/jb/layouts/partials/live/jb-tube.html
+++ b/themes/jb/layouts/partials/live/jb-tube.html
@@ -1,8 +1,8 @@
 <div class="jb-tube-wrapper">
   <div class="jb-tube" style="text-align: center;">
-    <div class="jb-tube-video">
-      <iframe id="liveStream" title="jblive.tv Stream" src="" allowfullscreen=""
-        sandbox="allow-same-origin allow-scripts allow-popups" width="960" height="540" frameborder="0"></iframe>
+    <div class="jb-tube-video columns is-centered is-mobile">
+      <iframe class="column is-10 is-10-fullhd" style="min-height: 65vh;" id="liveStream" title="jblive.tv Stream" src="" allowfullscreen=""
+        sandbox="allow-same-origin allow-scripts allow-popups" frameborder="0"></iframe>
     </div>
   </div>
   {{ $jbTube := resources.Get "js/jb-live.js" }}


### PR DESCRIPTION
close #278 
related #281 

I'd love to have maybe @gerbrent, @noblepayne (since he did #282), @reesericci (since opinion was asked in #278), or @reclaimingmytime (created #278)  and check to see if this size works for you all on both desktop & mobile.

You can test this locally by using [dev tools](https://developer.chrome.com/docs/devtools/device-mode/) (it's pretty much the same in firefox), or binding to all interfaces (`--bind 0.0.0.0` - use caution and make sure you're on a trusted network, because this will expose a port up to the local network) and navigating to your laptop's IP address.