### PR TITLE
adding plausible to website

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -26,3 +26,5 @@ twitch.parent = "jb-live.jupiterbroadcasting.net"
 # Calendar
 calendar.rss = "https://www.google.com/calendar/ical/jalb5frk4cunnaedbfemuqbhv4@group.calendar.google.com/public/basic.ics"
 calendar.embedd= "jalb5frk4cunnaedbfemuqbhv4@group.calendar.google.com"
+
+analytics = "https://plausible.ktz.cloud/js/plausible.js"

--- a/themes/jb/layouts/partials/footer.html
+++ b/themes/jb/layouts/partials/footer.html
@@ -71,5 +71,11 @@
 {{ $navigation := resources.Get "js/navigation.js" }}
 {{ $video := resources.Get "js/video.min.js" }}
 {{ $swiper := resources.Get "js/swiper-bundle.min.js" }}
-{{ $defaultJS := slice $swiper $navigation $video $main | resources.Concat "js/global.js" | resources.Minify | resources.Fingerprint }}
-<script src="{{ $defaultJS.Permalink }}"></script>
+{{ $defaultJS := slice $swiper $navigation $video $main | resources.Concat "js/global.js" }}
+{{ if hugo.IsProduction }}
+  {{ $defaultJS = $defaultJS | resources.Minify | resources.Fingerprint }}
+  {{ $plaus_analytics := resources.GetRemote site.Params.analytics (dict "filename" "cool_stuff") | resources.Minify | resources.Fingerprint }}
+  {{ $current_domain := (urls.Parse .Site.BaseURL).Host }}
+  <script defer data-domain="{{ $current_domain }}" src="{{ $plaus_analytics.Permalink }}" integrity="{{ $plaus_analytics.Data.Integrity }}"></script>
+{{ end }}
+<script src="{{ $defaultJS.Permalink }}" integrity="{{ $defaultJS.Data.Integrity }}"></script>


### PR DESCRIPTION
- specify url in params.toml
- adding integrity to main JS file to help w/security
- only minify + fingerprint during production deployment

This should work :upside_down_face: we'll have to ask @ironicbadger if he sees it in the dashboard since I tried to directly browse to it on his plausible instance and it appears it's not public.

Should close #70 