### PR TITLE
fixing the warnings that show during deployment

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -220,6 +220,7 @@ paginate = 12
   baseName = "webplayer"
 
 [outputs]
-  page = ["json","html","webplayer"]
+  page = ["html"]
+  # page = ["json","html","webplayer"]
   # section = ["html","rss"]
   section = ["html"]


### PR DESCRIPTION
apparently these page types were causing all the warnings to show up during development and deployment...I don't see why they're necessary?

![image](https://user-images.githubusercontent.com/10230166/184757997-46db7a2e-b07b-4bc9-b471-3e69aba1c676.png)


@StefanS-O , were those there for some reason?