### PR TITLE
Feat/subscribe/66

### DIFF
--- a/content/show/coder-radio/_index.md
+++ b/content/show/coder-radio/_index.md
@@ -23,7 +23,7 @@ podverse_podcast_id = "ZXd_1Ojd9"
 [links.reddit]
   url = "https://www.reddit.com/r/coderradio"  
 [links.shownotes]
-  url = "https://coder.show/"  
+  url = "https://coder.show"  
 [links.youtube]
   url="https://www.youtube.com/playlist?list=PLCB9545FD2C26E547"
 

--- a/content/show/coder-radio/subscribe.md
+++ b/content/show/coder-radio/subscribe.md
@@ -1,0 +1,6 @@
+---
+title: "Subscribe"
+date: 2022-08-16T05:32:13-04:00
+draft: true
+---
+

--- a/content/show/jupiter-extras/subscribe.md
+++ b/content/show/jupiter-extras/subscribe.md
@@ -1,0 +1,6 @@
+---
+title: "Subscribe"
+date: 2022-08-16T05:32:15-04:00
+draft: true
+---
+

--- a/content/show/linux-action-news/subscribe.md
+++ b/content/show/linux-action-news/subscribe.md
@@ -1,0 +1,6 @@
+---
+title: "Subscribe"
+date: 2022-08-16T05:32:17-04:00
+draft: true
+---
+

--- a/content/show/linux-unplugged/_index.md
+++ b/content/show/linux-unplugged/_index.md
@@ -21,7 +21,7 @@ podverse_podcast_id = "g40Um-HP1"
   url = "https://linuxunplugged.com/contact"  
 
 [links.shownotes]
-  url = "https://linuxunplugged.com/"
+  url = "https://linuxunplugged.com"
 
 [links.reddit]
   url="https://www.reddit.com/r/linuxunplugged/"

--- a/content/show/linux-unplugged/subscribe.md
+++ b/content/show/linux-unplugged/subscribe.md
@@ -1,0 +1,22 @@
+---
+title: "Subscribe"
+date: 2022-08-16T05:32:19-04:00
+draft: true
+rss: "https://linuxunplugged.com/rss"
+direct_links:
+    apple: https://itunes.apple.com/us/podcast/linux-unplugged-podcast/id687598126
+    google_play: https://playmusic.app.goo.gl/?ibi=com.google.PlayMusic&isi=691797987&ius=googleplaymusic&apn=com.google.android.music&link=https://play.google.com/music/m/I2hmp7hkpuqnu7qnbw5k46ngray?t%3DLINUX_Unplugged%26pcampaignid%3DMKT-na-all-co-pr-mu-pod-16
+    google_podcast: https://podcasts.google.com/?feed=aHR0cHM6Ly9mZWVkcy5maXJlc2lkZS5mbS9saW51eHVucGx1Z2dlZC9yc3M=
+    castro: https://castro.fm/podcast/82354b13-50fe-4972-a69d-7cfaab600459
+    castbox: https://castbox.fm/channel/LINUX-Unplugged-id2120644?country=us
+    overcast: https://overcast.fm/itunes687598126/linux-unplugged-podcast
+    pocket_cast: http://pca.st/itunes/687598126
+    spotify: https://open.spotify.com/show/7bVFJvj8A2ZuYVs5lS992b
+    stitcher: https://www.stitcher.com/podcast/jupiter-broadcasting/linux-unplugged
+    tunein: https://tunein.com/podcasts/Technology-Podcasts/LINUX-Unplugged-p1136199/
+    iheart_radio: https://www.iheart.com/podcast/256-linux-unplugged-31099185/
+    radio_public: https://radiopublic.com/linux-unplugged-G2BldG
+    podcast_index: https://podcastindex.org/podcast/575694
+
+---
+

--- a/content/show/office-hours/_index.md
+++ b/content/show/office-hours/_index.md
@@ -17,7 +17,7 @@ support_link = "https://jupitersignal.memberful.com/checkout?plan=53334"
 podverse_podcast_id = "GLuztlxs0-"
 
 [links.shownotes]
-  url="https://www.officehours.hair/"
+  url="https://www.officehours.hair"
 
 [links.email]
   url="https://www.officehours.hair/contact"

--- a/content/show/office-hours/subscribe.md
+++ b/content/show/office-hours/subscribe.md
@@ -1,0 +1,8 @@
++++
+title = "Subscribe"
+date = 2022-08-16T05:32:21-04:00
+draft = false
+rss = "https://www.officehours.hair/rss"
+[direct_links]
++++
+

--- a/content/show/self-hosted/subscribe.md
+++ b/content/show/self-hosted/subscribe.md
@@ -1,0 +1,6 @@
+---
+title: "Subscribe"
+date: 2022-08-16T05:32:25-04:00
+draft: true
+---
+

--- a/data/podcast_player.json
+++ b/data/podcast_player.json
@@ -1,0 +1,15 @@
+{
+    "apple": "https://a.fireside.fm/assets/badges/apple_podcasts-ec1be8838a44d6fba0799ec955af4c7e2c1067ec3de32be0e0afe4020c939f29.png",
+    "google_play": "https://a.fireside.fm/assets/badges/google_play-a253eed8c5cda3588a8ccf94edf7ec217bd5122726715c69b052b11376374a8d.png",
+    "google_podcast": "https://a.fireside.fm/assets/badges/google_podcasts-a66d7cc8179da7ad8485d8f41554b2126a2e3891c6a4f9d17b894058e0e21264.png",
+    "castro": "https://a.fireside.fm/assets/badges/castro-f3b3aae4bdfa7708998546abe274fd1553f47d1435670a8fc23649cf8aac93c9.png",
+    "castbox": "https://a.fireside.fm/assets/badges/castbox-366060f609828d6ae8269e0290cedb9aae6aa631578ace192912e8981a22f698.png",
+    "overcast": "https://a.fireside.fm/assets/badges/overcast-b8599ab35ab42cbbd693b92e1ed74b74f63539b64191eaebac20b8da8f12a943.png",
+    "pocket_cast": "https://a.fireside.fm/assets/badges/pocket_casts-50f7a8d1594b181d8883e7fed278189cb41f6c3963ccd6e53210aa3e1d60d5f1.png",
+    "spotify": "https://a.fireside.fm/assets/badges/spotify-c67de245cb003e33b1fbb18842612cd4c6cc350f49ededbbbebe63eff6d95b84.png",
+    "stitcher": "https://a.fireside.fm/assets/badges/stitcher-fbbd94e3db0c6b6c31a4d6a8f8c75b0d89899d7566267959aa7a3a3058a2592f.png",
+    "tunein": "https://a.fireside.fm/assets/badges/tunein-42eb01a84d186c9246be973f311db4cccc08c431c29793e9f85b1031100f9c51.png",
+    "iheart_radio": "https://a.fireside.fm/assets/badges/iHeartRadio-af4f88a6e29f0f978f9b5b50ac09e8dba9f6b9f2baadc4e6c647e5fb57c28aea.png",
+    "radio_public": "https://a.fireside.fm/assets/badges/radiopublic-c2299f15646cb7ddd2188b64c7867acc27b8b47bf7693c8a05793d2361ae9fed.png",
+    "podcast_index": "https://raw.githubusercontent.com/Podcastindex-org/web-ui/master/ui/images/brand-text.svg"
+}

--- a/themes/jb/assets/css/_layout.sass
+++ b/themes/jb/assets/css/_layout.sass
@@ -1,2 +1,3 @@
 @import "layout/section.sass"
 @import "layout/show-slider.scss"
+@import "layout/subscribe.sass"

--- a/themes/jb/assets/css/layout/subscribe.sass
+++ b/themes/jb/assets/css/layout/subscribe.sass
@@ -1,0 +1,9 @@
+@import "../libs/bulma/sass/utilities/mixins"
+
+.subscribe
+    &-logos
+        flex: 0 1 20%
+        +desktop
+            flex: 0 1 15%
+        +mobile
+            flex: 0 1 30%

--- a/themes/jb/layouts/_default/single.html
+++ b/themes/jb/layouts/_default/single.html
@@ -1,14 +1,47 @@
 {{ define "main" }}
 
+{{ $lastUrlElement := (delimit (split .Permalink "/" | last 2 | first 1 ) "") }}
+{{ $show_page := .Parent }}
+{{ if eq $lastUrlElement "subscribe" }}
+<div class="container my-5">
+  <img src="{{ $show_page.Params.header_image }}" alt="{{ $show_page.Title }}'s artwork">
+
+</div>
+{{ end }}
+
 <div class="container">
   <h1 class="title">{{.Title}}</h1>
 </div>
 
 <div class="container">
 
+{{ if eq $lastUrlElement "subscribe" }}
+
+  <div class="column">
+    <p class="mb-2">Get the latest episodes of {{ $show_page.Title }} automatically using the links above, or by copying and pasting the URL below into your favorite podcast app:</p>
+    <a href="{{ .Params.rss }}" class="mb-5 button is-dark">{{ $show_page.Title }}'s RSS Feed</a>
+    {{ with .Params.direct_links }}
+      <p>You can also subscribe with your favorite app directly, using the buttons below:</p>
+      <div class="is-flex is-flex-wrap-wrap is-justify-content-flex-start is-align-content-center">
+      {{ $icons_map := $.Site.Data.podcast_player }}
+      {{ range $key, $value := . }}
+      <!-- currently 90% of images grabbed from: https://linuxunplugged.com/subscribe -->
+        <div class="p-1 is-flex subscribe-logos">
+          <a class="is-flex is-align-content-center is-justify-content-center" href="{{ $value }}">
+            <img class="is-align-self-center" src="{{ index $icons_map $key }}" alt="{{ $key }} subscription link">
+          </a>
+        </div>
+      {{ end }}
+      </div>
+    {{ end }}
+  </div>
+{{ else }}
+
     <div class="column is-full content">
       {{.Content}}
     </div>
+
+{{ end }}
 
 </div>
 

--- a/themes/jb/layouts/show/list.html
+++ b/themes/jb/layouts/show/list.html
@@ -40,7 +40,8 @@
           </div>
         {{ end }}
 
-        {{ range (.Paginator 12).Pages }}
+        {{ $episode_paginator := .Paginate (where .Pages "Type" "episode") }}
+        {{ range $episode_paginator.Pages }}
         <div class="column is-6 is-4-fullhd is-4-desktop is-12-mobile"  style="display: flex;">
           {{ partial "episode/preview.html" . }}
         </div>


### PR DESCRIPTION
Lays the framework to #66 and once all content is added should close it

@gerbrent, if you end up making sure everything is working could you also add the rest of the links for this?

This should get you all the functionality you need to finish adding in the content for each show's subscription information.

Show with all links added

![image](https://user-images.githubusercontent.com/10230166/184874492-6c3a0a59-2e74-4147-9ef7-07fb035cc330.png)

Show with no links

![image](https://user-images.githubusercontent.com/10230166/184875030-d165f4e1-5d2a-4a23-9241-4905da8f9166.png)


future to-dos:
- [ ] swap out fireside images with local ones
- [ ] create a main jb.com/subscribe page (not implemented on this one)
- [ ] add each show's subscription information