### PR TITLE
redirector for /live to jb-live domain

### DIFF
--- a/static/live/index.html
+++ b/static/live/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en-us">
+
+<head>
+    <title>https://jb-live.jupiterbroadcasting.net</title>
+    <link rel="canonical" href="https://jb-live.jupiterbroadcasting.net">
+    <meta name="robots" content="noindex">
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://jb-live.jupiterbroadcasting.net">
+</head>
+
+</html>


### PR DESCRIPTION
unfortunately there doesn't appear to be a native way to redirect to a url that's not hugo based for the current site (i.e. jb-live.jb.net is technically a completely different deployment)

Normally if we'd redirect to another internal page to the repo it'd be easy (see #297 & #295), but since it's referencing an external site it not as easy (look at #294 for more info). 

So, the only way I can think to handle this is by defining a static file (which doesn't get access to hugo variables (I tried to reference it), pic below), and having the redirect there manually defined. (based on hugo's default page when calling an `alias`)

(what happened when trying to reference a hugo variable)
![image](https://user-images.githubusercontent.com/10230166/184981171-f5a3b5c7-a2ce-4148-9de9-82f81fcdb648.png)
