### PR TITLE
should deploy website now after scraper commits

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -6,6 +6,15 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  # source: https://stackoverflow.com/a/65698892
+  # triggers this deployment after scaper runs
+  #   for now this might have superfluous runs because the
+  #   scraper will run and not commit anything, but after #215 is solved
+  #   then it should only run after castablasta pushes a new episode
+  workflow_run:
+    workflows: ["Scrape and commit"]
+    types:
+      - completed
 
 jobs:
   deploy:


### PR DESCRIPTION
closes #365 

Tested on my repo (deploy to prod fails because I don't have environment stuff setup and can't access your server :upside_down_face: ), and it triggered right after the scraper finished.

![image](https://user-images.githubusercontent.com/10230166/187663419-1a965966-0505-4c95-befa-3ebf45e6da98.png)


BTW, E2E tests GH action are going to fail till #353 is merged.