### PR TITLE
GH workflow - remove redundant `git fetch`

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -21,7 +21,7 @@ jobs:
             USERNAME: ${{ secrets.VPS_DEPLOY_USER }}
             PORT: ${{ secrets.VPS_SSH_PORT }}
             KEY: ${{ secrets.VPS_SSHKEY }}
-            script: cd ${{ secrets.VPS_PROJECT_PATH }} && git fetch && git pull
+            script: cd ${{ secrets.VPS_PROJECT_PATH }} && git pull
             
       - name: Deploy
         uses: appleboy/ssh-action@master


### PR DESCRIPTION
this file features a `git fetch && git pull` - this is rather redundant, considering the [Git Documentation](https://www.git-scm.com/docs/git-pull):

> git pull runs `git fetch` with the given parameters and then depending on configuration options or command line flags, will call either `git rebase` or `git merge` to reconcile diverging branches.

so, while very minor, we can I believe safely drop the redundant `git fetch`