### PR TITLE
allowing PRs to run E2E tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,6 +1,16 @@
 name: E2E Tests
 
-on: [push]
+on:
+  # keeping this till we figure out #371, so we can at least validate the
+  #   scrapper PRs aren't breaking things
+  push:
+    branches: [ main ]
+
+  # https://frontside.com/blog/2020-05-26-github-actions-pull_request/
+  pull_request:
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   e2e-tests:


### PR DESCRIPTION
So...I've typically been disabling the different CI/CD test that we created on my personal repo. Most of them were deployment things which weren't going to work on my account and then I disabled E2E test because they were failing.

But after disabling E2E tests, and I'd make [a PR](https://github.com/JupiterBroadcasting/jupiterbroadcasting.com/pull/383)...the E2E tests didn't run for my PR. Then I looked at the config again and it's only running on push'es.

https://github.com/JupiterBroadcasting/jupiterbroadcasting.com/blob/d141be3dcfefd101185cefdb814dc567298d91e5/.github/workflows/e2e.yml#L3

Which means when people do PRs it won't require it to run from JB's repo when someone does a pull_request.

This'll allow tests to not run if they disable it (like what I did), and so I think we should force the tests to run when people submit PRs (also keeping the push to main till we figure out #371).

Here is an example of it working after I merged it with my main on my fork (check under the all tests section near the bottom): https://github.com/elreydetoda/jupiterbroadcasting.com/pull/7