### PR TITLE
disable Archive menu item temporarily

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -143,11 +143,11 @@ paginate = 12
         weight =82
         parent = "people"
 
-[[Menu.Main]]
-    name = "Archive"
-    identifier = "archive"
-    url = "/archive"
-    weight =90
+#[[Menu.Main]]
+    #name = "Archive"
+    #identifier = "archive"
+    #url = "/archive"
+    #weight =90
 
 [[Menu.Main]]
     name = "Community"


### PR DESCRIPTION
Temporarily disable Archive menu item until the archive can be permanently integrated into Hugo. Currently links to a placeholder page...

![image](https://user-images.githubusercontent.com/7018928/188937869-7e80cc52-d1de-43c5-bec0-2be7617769b7.png)
