### PR TITLE
Fixes #408 Set Aspect Ratio and Object Fit

### DIFF
--- a/themes/jb/assets/css/helpers/sizing.sass
+++ b/themes/jb/assets/css/helpers/sizing.sass
@@ -3,3 +3,6 @@
     height: 100% !important
   &__is-fullwidth
     width: 100% !important
+  &__set-1by1
+    aspect-ratio: 1/1
+    object-fit: cover

--- a/themes/jb/layouts/partials/people/smallest.html
+++ b/themes/jb/layouts/partials/people/smallest.html
@@ -2,7 +2,7 @@
   <a href="/{{ .Type | pluralize }}/{{ .Params.username }}">
     <figure class="image is-96x96" style="margin: 0 auto">
     <!-- <figure class="image is-96x96 my-0 mx-auto"> -->
-      <img src="{{ .Params.avatar }}" alt="{{ .Title }}" class="is-rounded" />
+      <img src="{{ .Params.avatar }}" alt="{{ .Title }}" class="custom__set-1by1 is-rounded" />
     </figure>
     <strong>{{ .Title }}</strong>
   </a>


### PR DESCRIPTION
Creates a custom size class to set image aspect ratio to 1:1 and object fit to cover for non-square images. 

Fixes #408 