### PR TITLE
Add Matrix well-known client file

### DIFF
--- a/static/.well-known/matrix/client
+++ b/static/.well-known/matrix/client
@@ -1,0 +1,5 @@
+{
+  "m.homeserver": {
+    "base_url": "https://colony.jupiterbroadcasting.com"
+  }
+}


### PR DESCRIPTION
The Matrix spec has a defined process to allow clients to automatically discover the correct base URL for a home server using only the users MXID.

https://matrix.org/docs/spec/client_server/r0.4.0.html#well-known-uri

Adding this file will allow users to sign in by providing a client like element with `chrislas:jupiterbroadcasting.com` for example and the client will find the correct subdomain of the server.