### PR TITLE
Only attempt setting src when livestream ID is found.

### DIFF
--- a/themes/jb/layouts/partials/live/jb-tube.html
+++ b/themes/jb/layouts/partials/live/jb-tube.html
@@ -6,7 +6,12 @@
   <script type="text/javascript" src="{{ $jbTube.Permalink }}" integrity="{{ $jbTube.Data.Integrity }}"></script>
   <script>
     window.onload = () => {
-      jbLive().then(result => document.getElementById('liveStream').src = result);
+      jbLive().then(result =>  {
+        let liveStream = document.getElementById('liveStream');
+        if(liveStream)
+          liveStream.src = result
+        }
+      );
       doLiveHighlight();
     }
   </script>


### PR DESCRIPTION
Resolves #328 attempting to set src when the live stream id is not present.