### PR TITLE
Link to join Matrix Chat Room when creating a new issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Matrix Chat
+    url: https://matrix.to/#/#jupiterweb:jupiterbroadcasting.com
+    about: Our base of operations for group discussions on this project is our Matrix chat room


### PR DESCRIPTION
Add an option to join the Matrix chat for the website when creating a new issue

Screenshot is an example from [this repo](https://github.com/linuxserver/docker-baseimage-alpine/issues/new/choose).
![image](https://user-images.githubusercontent.com/34293941/192164645-5dcf4f90-0f56-41cd-8505-cd191b7ca104.png)
