### PR TITLE
Render Full Contact Form even when there are Validation Errors

### DIFF
--- a/test/e2e/test_contact.py
+++ b/test/e2e/test_contact.py
@@ -1,11 +1,9 @@
-import time
 from pathlib import Path
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Page, FrameLocator, Locator
 
 
 def test_contact_screenshot(page: Page, screenshot_dir: Path):
-    page.goto("/contact")
-    page.pause()
+    page.goto("/contact", wait_until="networkidle")
     page.screenshot(path=f"{screenshot_dir}/contact.png", full_page=True)
 
 def test_submit_button_visible(page: Page, screenshot_dir: Path):
@@ -17,10 +15,9 @@ def test_submit_button_visible(page: Page, screenshot_dir: Path):
     page.wait_for_load_state("networkidle")
 
     # Scroll to the top (Page is current about 1400px)
-    page.mouse.wheel(0.0, -1500.0)
-    time.sleep(1) # Give time to scroll to the top
+    page.locator("h1").scroll_into_view_if_needed()
 
-    frame_height: float = float(page.get_attribute(selector="#contact-frame", name="height")) + page.locator(selector="#contact-frame").bounding_box().get("y")
+    frame_height: float = float(page.locator("#contact-frame").get_attribute("height")) + page.locator(selector="#contact-frame").bounding_box().get("y")
 
     button_location: dict = submit_button.bounding_box()
     if button_location is None:

--- a/test/e2e/test_contact.py
+++ b/test/e2e/test_contact.py
@@ -1,4 +1,4 @@
-from pytest import mark
+import time
 from pathlib import Path
 from playwright.sync_api import Page, expect
 
@@ -8,7 +8,6 @@ def test_contact_screenshot(page: Page, screenshot_dir: Path):
     page.pause()
     page.screenshot(path=f"{screenshot_dir}/contact.png", full_page=True)
 
-@mark.skip(reason="Not finished implementing")
 def test_submit_button_visible(page: Page, screenshot_dir: Path):
     page.goto("/contact")
     contact_form: FrameLocator = page.frame_locator('#contact-frame')
@@ -17,16 +16,16 @@ def test_submit_button_visible(page: Page, screenshot_dir: Path):
     submit_button.click()
     page.wait_for_load_state("networkidle")
 
-    frame_height: int = int(page.get_attribute(selector="#contact-frame", name="height"))
+    # Scroll to the top (Page is current about 1400px)
+    page.mouse.wheel(0.0, -1500.0)
+    time.sleep(1) # Give time to scroll to the top
 
-    # Bounding Box is relative to view port, making this test invalid.
-    # Need to find a way to get the bottom of the submit button in
-    # pixels on the form to check if it is greater than the size of
-    # the iframe
+    frame_height: float = float(page.get_attribute(selector="#contact-frame", name="height")) + page.locator(selector="#contact-frame").bounding_box().get("y")
+
     button_location: dict = submit_button.bounding_box()
     if button_location is None:
         assert False, "Submit Button is hidden"
     button_bottom: float = button_location.get("y") + button_location.get("height")
 
-    assert form_height <= frame_height, "Form content is running off the iframe"
-    page.screenshot(path=f"{screenshot_dir}/contact_errors.png")
+    page.screenshot(path=f"{screenshot_dir}/contact_errors.png", full_page=True)
+    assert button_bottom <= frame_height, "Form content is running off the iframe"

--- a/test/e2e/test_contact.py
+++ b/test/e2e/test_contact.py
@@ -1,0 +1,32 @@
+from pytest import mark
+from pathlib import Path
+from playwright.sync_api import Page, expect
+
+
+def test_contact_screenshot(page: Page, screenshot_dir: Path):
+    page.goto("/contact")
+    page.pause()
+    page.screenshot(path=f"{screenshot_dir}/contact.png", full_page=True)
+
+@mark.skip(reason="Not finished implementing")
+def test_submit_button_visible(page: Page, screenshot_dir: Path):
+    page.goto("/contact")
+    contact_form: FrameLocator = page.frame_locator('#contact-frame')
+    submit_button: Locator = contact_form.locator("#saveForm")
+
+    submit_button.click()
+    page.wait_for_load_state("networkidle")
+
+    frame_height: int = int(page.get_attribute(selector="#contact-frame", name="height"))
+
+    # Bounding Box is relative to view port, making this test invalid.
+    # Need to find a way to get the bottom of the submit button in
+    # pixels on the form to check if it is greater than the size of
+    # the iframe
+    button_location: dict = submit_button.bounding_box()
+    if button_location is None:
+        assert False, "Submit Button is hidden"
+    button_bottom: float = button_location.get("y") + button_location.get("height")
+
+    assert form_height <= frame_height, "Form content is running off the iframe"
+    page.screenshot(path=f"{screenshot_dir}/contact_errors.png")

--- a/test/e2e/test_contact.py
+++ b/test/e2e/test_contact.py
@@ -1,11 +1,24 @@
 from pathlib import Path
 from playwright.sync_api import Page, FrameLocator, Locator
 
-
+"""
+Take a screenshot of the contact page for manual review
+"""
 def test_contact_screenshot(page: Page, screenshot_dir: Path):
     page.goto("/contact", wait_until="networkidle")
     page.screenshot(path=f"{screenshot_dir}/contact.png", full_page=True)
 
+"""
+This test ensures that the "Submit" button at the bottom of the contact form is always visible to the user, even if they forget the fill in the fields. This
+test also saves a screenshot of the contact page after the form validation errors have been generated for manual review if needed.
+
+Steps:
+  1. Go to contact page
+  2. Click "Submit" button without filling out any data
+  3. Get the height of the iframe (defined as an html attribute) and adds it to the distance from the top of the screen to the top of the iframe
+  4. Measure the height of the top of the screen to the bottom of the "Submit" button
+  5. Pass if the distance from the bottom of the iframe is greater than the distance to the bottom of the button in the iframe (ie. the button can be seen)
+"""
 def test_submit_button_visible(page: Page, screenshot_dir: Path):
     page.goto("/contact")
     contact_form: FrameLocator = page.frame_locator('#contact-frame')
@@ -14,11 +27,13 @@ def test_submit_button_visible(page: Page, screenshot_dir: Path):
     submit_button.click()
     page.wait_for_load_state("networkidle")
 
-    # Scroll to the top (Page is current about 1400px)
     page.locator("h1").scroll_into_view_if_needed()
 
+    # This test assumes the iframe will always be rendered, if the test fails here, the iframe is missing
     frame_height: float = float(page.locator("#contact-frame").get_attribute("height")) + page.locator(selector="#contact-frame").bounding_box().get("y")
 
+    # This is just a precautionary measure to ensure the submit button is on the screen it'll return None if it's not, and since here are more places that
+    # use the value from the bounding_box's return ensuring it's not None
     button_location: dict = submit_button.bounding_box()
     if button_location is None:
         assert False, "Submit Button is hidden"

--- a/themes/jb/layouts/contact/single.html
+++ b/themes/jb/layouts/contact/single.html
@@ -6,7 +6,7 @@
   <div class="container">
     <div class="content">
         <h1>{{.Title}}</h1>
-        <iframe height="780" allowTransparency="true" frameborder="0" scrolling="no" style="width:100%;border:none"  src="https://jblive.wufoo.com/embed/w7x2r7/"><a href="https://jblive.wufoo.com/forms/w7x2r7/">Fill out my Wufoo form!</a></iframe>
+        <iframe height="830" allowTransparency="true" frameborder="0" scrolling="no" style="width:100%;border:none"  src="https://jblive.wufoo.com/embed/w7x2r7/"><a href="https://jblive.wufoo.com/forms/w7x2r7/">Fill out my Wufoo form!</a></iframe>
     </div>
   </div>
 {{end}}

--- a/themes/jb/layouts/contact/single.html
+++ b/themes/jb/layouts/contact/single.html
@@ -5,8 +5,8 @@
 {{ define "main" }}
   <div class="container">
     <div class="content">
-        <h1>{{.Title}}</h1>
-        <iframe height="830" allowTransparency="true" frameborder="0" scrolling="no" style="width:100%;border:none"  src="https://jblive.wufoo.com/embed/w7x2r7/"><a href="https://jblive.wufoo.com/forms/w7x2r7/">Fill out my Wufoo form!</a></iframe>
+      <h1>{{.Title}}</h1>
+      <iframe id="contact-frame" height="830" allowTransparency="true" frameborder="0" scrolling="no" style="width:100%;border:none"  src="https://jblive.wufoo.com/embed/w7x2r7/"><a target="_blank" href="https://jblive.wufoo.com/forms/w7x2r7/">Fill out the form here</a></iframe>
     </div>
   </div>
 {{end}}


### PR DESCRIPTION
Fixes #437

* Increase size of contact form `iframe` to show submit button even when there are validation errors in the form
* Implement basic tests to check if the submit button is within the bounds of the contact form `iframe`

![contact form with errors](https://user-images.githubusercontent.com/34293941/194333203-f0a1fbd2-a296-47b2-820c-3e02a964b99f.png)
