### PR TITLE
Add Fleet config folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ $RECYCLE.BIN/
 .vscode
 .kateproject
 .kateproject.local
+.fleet
 
 
 # Ignore all the scraped data

--- a/content/show/coder-radio/0487.md
+++ b/content/show/coder-radio/0487.md
@@ -1,0 +1,68 @@
+{
+  "type": "episode",
+  "draft": false,
+  "show_slug": "coder-radio",
+  "show_name": "Coder Radio",
+  "episode": 487,
+  "episode_padded": "0487",
+  "episode_guid": "a86db702-c529-413c-ad75-ee7993cbf199",
+  "slug": "487",
+  "title": "Casual Coders",
+  "description": "Elon Musk's leaked messages reveal how tech CEOs think and talk about their employees, and we dig in.",
+  "date": "2022-10-12T11:00:00-07:00",
+  "header_image": "/images/shows/coder-radio.png",
+  "categories": [
+    "Coder Radio"
+  ],
+  "tags": [
+    "3d media",
+    "android roms",
+    "coder radio",
+    "development podcast",
+    "jason calacanis",
+    "leaked messages",
+    "misinformation",
+    "musk",
+    "paypal",
+    "return-to-office mandate",
+    "twitter",
+    "vr",
+    "watch"
+  ],
+  "hosts": [
+    "chris",
+    "michael"
+  ],
+  "guests": [],
+  "sponsors": [
+    "linode.com-cr",
+    "tailscale.com-cr"
+  ],
+  "podcast_duration": "00:59:06",
+  "podcast_file": "https://aphid.fireside.fm/d/1437767933/b44de5fa-47c1-4e94-bf9e-c72f8d1c8f5d/a86db702-c529-413c-ad75-ee7993cbf199.mp3",
+  "podcast_bytes": 49653991,
+  "podcast_chapters": null,
+  "podcast_alt_file": null,
+  "podcast_ogg_file": null,
+  "video_file": null,
+  "video_hd_file": null,
+  "video_mobile_file": null,
+  "youtube_link": null,
+  "jb_url": null,
+  "fireside_url": "/487"
+}
+
+
+### Episode Links
+
+  * [PayPal Misinformation Fines Musk Criticized Were Published by Mistake](https://www.bloomberg.com/news/articles/2022-10-10/paypal-misinformation-fines-musk-criticized-were-published-by-mistake "PayPal Misinformation Fines Musk Criticized Were Published by Mistake") — Policy update threatened penalty of $2,500 for each violation
+  * [alex 🤷🏽‍♂️😬👍🏾 on Twitter](https://twitter.com/gigatexal/status/1578751320005099520 "alex 🤷🏽‍♂️😬👍🏾 on Twitter") — Yo this is a really compelling testimonial from ⁦ @ChrisLAS on the merits of 3D media — shame it’s not really taking off or didn’t take off. ⁦@CoderRadioShow ⁩ any thoughts why?
+  * [It’s official, Elon Musk is buying Twitter](https://techcrunch.com/2022/10/04/elon-intends-buy-twitter/ "It’s official, Elon Musk is buying Twitter") — It sure looks like Elon Musk’s $44 billion Twitter takeover is actually happening.
+  * [Michael Dominick on Twitter](https://twitter.com/dominucco/status/1577413528985616384 "Michael Dominick on Twitter") — What's the value of avoiding a possibly embarrassing and likely damaging deposition? Apparently, $44B. Damn! #tech
+  * [Elon Musk: Twitter won't 'take yes for an answer'](https://www.bbc.com/news/business-63166568 "Elon Musk: Twitter won't 'take yes for an answer'") — Billionaire Elon Musk has said he aims to complete his purchase of Twitter by the end of the month, but the company "will not take yes for an answer".
+  * [Elon Musk and Jason Calacanis's messages reveal how return-to-office mandates can be used to get workers to quit](https://fortune.com/2022/10/06/elon-musk-jason-calacanis-return-to-office-gentlemens-layoffs-twitter/ "Elon Musk and Jason Calacanis's messages reveal how return-to-office mandates can be used to get workers to quit") — Elon Musk’s Twitter acquisition saga may be exhausting, but it has revealed how some business leaders are thinking privately about return-to-office mandates.
+  * [Swimply](https://swimply.com/ "Swimply") — Rent your own private pool by the hour.
+  * [Bucco Capital on Twitter](https://twitter.com/buccocapital/status/1576909546164928513 "Bucco Capital on Twitter") — “Internally, we called it the LPA cycle: Launch, Promo, Abandon”
+  * [Grab a new Podcast App](https://podcastindex.org/apps?appTypes=app&elements=Value "Grab a new Podcast App") — Upgrade to a Podcasting 2.0 app and send a Boost into the show.
+
+

--- a/content/show/linux-action-news/0262.md
+++ b/content/show/linux-action-news/0262.md
@@ -1,0 +1,181 @@
+{
+  "type": "episode",
+  "draft": false,
+  "show_slug": "linux-action-news",
+  "show_name": "Linux Action News",
+  "episode": 262,
+  "episode_padded": "0262",
+  "episode_guid": "91eea89e-06ad-402b-a4be-d6d00703a30b",
+  "slug": "262",
+  "title": "Linux Action News 262",
+  "description": "Plasma 5.26's standout features, Canonical flips the script on Red Hat, and why Android is leaking traffic outside VPNs.",
+  "date": "2022-10-13T08:15:00-07:00",
+  "header_image": "/images/shows/linux-action-news.png",
+  "categories": [
+    "Linux Action News"
+  ],
+  "tags": [
+    "activities",
+    "android",
+    "apple",
+    "asrock",
+    "aura",
+    "canonical",
+    "captive portal",
+    "chrome os",
+    "chromebooks",
+    "cloud gaming",
+    "compliance",
+    "data leak",
+    "desktop linux",
+    "discrete graphics",
+    "dns",
+    "enterprise",
+    "firefox",
+    "google",
+    "gpu",
+    "grapheneos",
+    "gunnir",
+    "intel arc graphics",
+    "ios",
+    "kate",
+    "kde",
+    "kwin",
+    "kwrite",
+    "lenovo",
+    "linux action news",
+    "linux news podcast",
+    "mesa",
+    "mullvad vpn",
+    "neon",
+    "open-source graphics",
+    "pixel",
+    "plank",
+    "plasma 5.26",
+    "plasma big screen",
+    "plasmoids",
+    "privacy",
+    "security",
+    "software upgrades",
+    "stadia",
+    "system settings",
+    "thunderbolt",
+    "ubuntu pro",
+    "vlc",
+    "vpn",
+    "wayland",
+    "widgets",
+    "wifi",
+    "x11"
+  ],
+  "hosts": [
+    "chris",
+    "wes"
+  ],
+  "guests": [],
+  "sponsors": [
+    "kolide.com-lan",
+    "linode.com-lan"
+  ],
+  "podcast_duration": "00:20:46",
+  "podcast_file": "https://aphid.fireside.fm/d/1437767933/dec90738-e640-45e5-b375-4573052f4bf4/91eea89e-06ad-402b-a4be-d6d00703a30b.mp3",
+  "podcast_bytes": 17451385,
+  "podcast_chapters": {
+    "version": "1.1.0",
+    "chapters": [
+      {
+        "startTime": 0,
+        "title": "Intro",
+        "img": null,
+        "url": null,
+        "toc": null,
+        "endTime": null,
+        "location": null
+      },
+      {
+        "startTime": 15,
+        "title": "Plasma 5.26",
+        "img": null,
+        "url": null,
+        "toc": null,
+        "endTime": null,
+        "location": null
+      },
+      {
+        "startTime": 177,
+        "title": "Cloud Gaming Chromebooks",
+        "img": null,
+        "url": null,
+        "toc": null,
+        "endTime": null,
+        "location": null
+      },
+      {
+        "startTime": 286,
+        "title": "Intel Arc",
+        "img": null,
+        "url": null,
+        "toc": null,
+        "endTime": null,
+        "location": null
+      },
+      {
+        "startTime": 407,
+        "title": "Ubuntu Pro For All",
+        "img": null,
+        "url": null,
+        "toc": null,
+        "endTime": null,
+        "location": null
+      },
+      {
+        "startTime": 799,
+        "title": "Leaky Android",
+        "img": null,
+        "url": null,
+        "toc": null,
+        "endTime": null,
+        "location": null
+      },
+      {
+        "startTime": 1182,
+        "title": "Outro",
+        "img": null,
+        "url": null,
+        "toc": null,
+        "endTime": null,
+        "location": null
+      }
+    ],
+    "author": "Jupiter Broadcasting",
+    "title": "Linux Action News 262",
+    "podcastName": "Linux Action News",
+    "description": null,
+    "fileName": null,
+    "waypoints": null
+  },
+  "podcast_alt_file": null,
+  "podcast_ogg_file": null,
+  "video_file": null,
+  "video_hd_file": null,
+  "video_mobile_file": null,
+  "youtube_link": null,
+  "jb_url": null,
+  "fireside_url": "/262"
+}
+
+
+### Episode Links
+
+  * [Plasma 5.26 Released](https://kde.org/announcements/plasma/5/5.26.0/ "Plasma 5.26 Released") — Plasma 5.26 comes with new and tweaked widgets, improves the desktop experience leaps and bounds, and Plasma Big Screen's app family grows
+  * [These weeks in KDE: Akademy and Plasma 5.26](https://pointieststick.com/2022/10/08/these-weeks-in-kde-akademy-and-plasma-5-26/ "These weeks in KDE: Akademy and Plasma 5.26")
+  * [Google Reveals ‘First Laptops Built For Cloud Gaming’ ](https://www.forbes.com/sites/krisholt/2022/10/11/google-stadia-cloud-gaming-laptops-chromebook-chrome-os-xbox-cloud-gaming-geforce-now-amazon-luna-asus-acer-lenovo/ "Google Reveals ‘First Laptops Built For Cloud Gaming’ ") — Google says the Acer Chromebook 516 GE, ASUS Chromebook Vibe CX55 Flip and Lenovo Ideapad Gaming Chromebook all have refresh rates of at least 120Hz, displays with up to 1600p resolution, immersive audio and, critically for cloud gaming, WiFi 6 or 6E connectivity.
+  * [Intel Arc Graphics - A750 and A770 GPUs Release](https://game.intel.com/story/intel-arc-graphics-release/ "Intel Arc Graphics - A750 and A770 GPUs Release") — The Intel Arc A750 and A770 GPUs officially launch today, October 12th in select markets. Everyone at Intel is beyond thrilled to get graphics cards with modern features and extremely competitive performance-per-dollar into your hands.
+  * [Intel Arc Graphics Running On Fully Open-Source Linux Driver](https://www.phoronix.com/review/intel-arc-graphics-linux "Intel Arc Graphics Running On Fully Open-Source Linux Driver")
+  * [Canonical Launches Free Ubuntu Pro Subscriptions for Everyone](https://9to5linux.com/canonical-launches-free-ubuntu-pro-subscriptions-for-everyone "Canonical Launches Free Ubuntu Pro Subscriptions for Everyone") — Ubuntu Pro is available for every supported Ubuntu LTS version, starting with Ubuntu 16.04 ESM and up to Ubuntu 22.04 LTS. 
+  * [Android leaks some traffic even when ‘Always-on VPN’ is enabled](https://www.bleepingcomputer.com/news/google/android-leaks-some-traffic-even-when-always-on-vpn-is-enabled/ "Android leaks some traffic even when ‘Always-on VPN’ is enabled") — The data being leaked outside VPN tunnels includes source IP addresses, DNS lookups, HTTPS traffic, and likely also NTP traffic.
+  * [Incorrect VPN lockdown documentation [249990229] - Visible to Public - Issue Tracker](https://issuetracker.google.com/issues/249990229?pli=1 "Incorrect VPN lockdown documentation \[249990229\] - Visible to Public - Issue Tracker")
+  * [Android leaks connectivity check traffic](https://mullvad.net/en/blog/2022/10/10/android-leaks-connectivity-check-traffic/ "Android leaks connectivity check traffic") — As a closing note, we would like to recommend Google to adopt the ability to disable the connectivity checks, like on GrapheneOS, into stock Android.
+  * [iOS VPN apps have another flaw: excluding many Apple apps](https://9to5mac.com/2022/10/12/ios-vpn-apps-2/ "iOS VPN apps have another flaw: excluding many Apple apps") — We confirm that iOS 16 does communicate with Apple services outside an active VPN tunnel. Worse, it leaks DNS requests. Apple services that escape the VPN connection include Health, Maps, and Wallet.
+
+

--- a/content/show/linux-unplugged/0479.md
+++ b/content/show/linux-unplugged/0479.md
@@ -1,0 +1,238 @@
+{
+  "type": "episode",
+  "draft": false,
+  "show_slug": "linux-unplugged",
+  "show_name": "LINUX Unplugged",
+  "episode": 479,
+  "episode_padded": "0479",
+  "episode_guid": "e50e5309-c8d8-4a94-b425-8a6d07444fd4",
+  "slug": "479",
+  "title": "Good Software, Bad Blood",
+  "description": "What the heck is going on? Fedora is dropping features, GNOME is getting Iced, and the mistake we'll never make again. We've got a lot to sort out.",
+  "date": "2022-10-09T19:45:00-07:00",
+  "header_image": "/images/shows/linux-unplugged.png",
+  "categories": [
+    "LINUX Unplugged"
+  ],
+  "tags": [
+    "acastus photon",
+    "accessibility",
+    "amd",
+    "auto move windows",
+    "c",
+    "codecs",
+    "collaboration",
+    "cosmic",
+    "elm",
+    "elm architecture",
+    "fedora",
+    "geocache",
+    "gnome",
+    "gnome extensions",
+    "google",
+    "gtk",
+    "h.264",
+    "h.265",
+    "iced",
+    "igpu",
+    "intel",
+    "jupiter broadcasting",
+    "linux podcast",
+    "linux unplugged",
+    "lokinet",
+    "mpeg-la",
+    "nextcloud",
+    "nextcloud hub 3",
+    "nvidia",
+    "open-source graphics",
+    "osint",
+    "pelias",
+    "pop!_os",
+    "red hat",
+    "rust",
+    "sharepoint",
+    "silverblue",
+    "software licenses",
+    "software patents",
+    "solaris",
+    "stadia",
+    "system76",
+    "tasks",
+    "todo",
+    "uav"
+  ],
+  "hosts": [
+    "chris",
+    "wes",
+    "brent"
+  ],
+  "guests": [],
+  "sponsors": [
+    "bitwarden.com-lup",
+    "linode.com-lup",
+    "tailscale.com-lup"
+  ],
+  "podcast_duration": "01:21:02",
+  "podcast_file": "https://aphid.fireside.fm/d/1437767933/f31a453c-fa15-491f-8618-3f71f1d565e5/e50e5309-c8d8-4a94-b425-8a6d07444fd4.mp3",
+  "podcast_bytes": 68080140,
+  "podcast_chapters": {
+    "version": "1.1.0",
+    "chapters": [
+      {
+        "startTime": 0,
+        "title": "Pre-Show",
+        "img": null,
+        "url": null,
+        "toc": null,
+        "endTime": null,
+        "location": null
+      },
+      {
+        "startTime": 126,
+        "title": "Intro",
+        "img": null,
+        "url": null,
+        "toc": null,
+        "endTime": null,
+        "location": null
+      },
+      {
+        "startTime": 248,
+        "title": "Draftin' Off Jupes",
+        "img": null,
+        "url": null,
+        "toc": null,
+        "endTime": null,
+        "location": null
+      },
+      {
+        "startTime": 403,
+        "title": "H-No-64",
+        "img": null,
+        "url": null,
+        "toc": null,
+        "endTime": null,
+        "location": null
+      },
+      {
+        "startTime": 1095,
+        "title": "Oxidizing Cosmic",
+        "img": null,
+        "url": null,
+        "toc": null,
+        "endTime": null,
+        "location": null
+      },
+      {
+        "startTime": 1922,
+        "title": "Housekeeping",
+        "img": null,
+        "url": null,
+        "toc": null,
+        "endTime": null,
+        "location": null
+      },
+      {
+        "startTime": 2078,
+        "title": "Baller Boosts",
+        "img": null,
+        "url": null,
+        "toc": null,
+        "endTime": null,
+        "location": null
+      },
+      {
+        "startTime": 2260,
+        "title": "One Geocache Down",
+        "img": null,
+        "url": null,
+        "toc": null,
+        "endTime": null,
+        "location": null
+      },
+      {
+        "startTime": 2415,
+        "title": "The Portland Promise",
+        "img": null,
+        "url": null,
+        "toc": null,
+        "endTime": null,
+        "location": null
+      },
+      {
+        "startTime": 3105,
+        "title": "Feedback",
+        "img": null,
+        "url": null,
+        "toc": null,
+        "endTime": null,
+        "location": null
+      },
+      {
+        "startTime": 3282,
+        "title": "Boosts",
+        "img": null,
+        "url": null,
+        "toc": null,
+        "endTime": null,
+        "location": null
+      },
+      {
+        "startTime": 4642,
+        "title": "Outro",
+        "img": null,
+        "url": null,
+        "toc": null,
+        "endTime": null,
+        "location": null
+      },
+      {
+        "startTime": 4773,
+        "title": "Post-Show",
+        "img": null,
+        "url": null,
+        "toc": null,
+        "endTime": null,
+        "location": null
+      }
+    ],
+    "author": "Jupiter Broadcasting",
+    "title": "479: Good Software, Bad Blood",
+    "podcastName": "LINUX Unplugged",
+    "description": null,
+    "fileName": null,
+    "waypoints": null
+  },
+  "podcast_alt_file": null,
+  "podcast_ogg_file": null,
+  "video_file": null,
+  "video_hd_file": null,
+  "video_mobile_file": null,
+  "youtube_link": null,
+  "jb_url": null,
+  "fireside_url": "/479"
+}
+
+
+### Episode Links
+
+  * [Tasks - Nextcloud Apps](https://apps.nextcloud.com/apps/tasks "Tasks - Nextcloud Apps") — Tasks can be shared between users. Tasks can be synchronized using CalDAV (each task list is linked to an Nextcloud calendar, to sync it to your local client: Thunderbird, Evolution, KDE Kontact, iCal … - just add the calendar as a remote calendar in your client). You can download your tasks as ICS files using the download button for each calendar.
+  * [Home Assistant Yellow](https://www.crowdsupply.com/nabu-casa/home-assistant-yellow "Home Assistant Yellow") — Home Assistant Yellow integrates 1,000+ different devices and services, allowing you to create powerful automations and get insight into your energy usage. All from an easy-to-use interface that runs 100% locally without anything in the cloud.
+  * [Oh No!😱Fedora is Dropping Support for Popular Video Codecs](https://news.itsfoss.com/fedora-drops-vaapi-codec/ "Oh No!😱Fedora is Dropping Support for Popular Video Codecs") — Primarily, it will affect AMD GPU users using open-source drivers, preventing them using GPU acceleration to play video content that requires using these codecs. Additionally, it also affects any user who uses open-source graphics drivers, even if they run iGPUs on Intel chips.
+  * [recent commit to Mesa on Fedora](https://src.fedoraproject.org/rpms/mesa/c/94ef544b3f2125912dfbff4c6ef373fe49806b52?branch=rawhide "recent commit to Mesa on Fedora")
+  * [Tom Callaway on Twitter](https://twitter.com/spotfoss/status/1575885891922690048 "Tom Callaway on Twitter")
+  * [System76’s Pop!_OS COSMIC Desktop To Make Use Of Iced Rust Toolkit](https://www.phoronix.com/news/COSMIC-Desktop-Iced-Toolkit "System76’s Pop!_OS COSMIC Desktop To Make Use Of Iced Rust Toolkit") — The UX team has been carefully designing widgets and applications over the last year. We are now at the point where it is critical for the engineering team to decide upon a GUI toolkit for COSMIC. After much deliberation and experimentation over the last year, the engineering team has decided to use Iced instead of GTK.
+  * [Reddit Comment That Kicked All this Off](https://www.reddit.com/r/pop_os/comments/xs87ed/comment/iqjc35b/?utm_source=reddit&utm_medium=web2x&context=3 "Reddit Comment That Kicked All this Off")
+  * [Iced toolkit](https://github.com/iced-rs/iced "Iced toolkit") — A cross-platform GUI library for Rust focused on simplicity and type-safety. Inspired by Elm.
+  * [Comment thread on Reddit that kicked it all off](https://www.reddit.com/r/pop_os/comments/xs87ed/comment/iqo4oej/?utm_source=reddit&utm_medium=web2x&context=3 "Comment thread on Reddit that kicked it all off")
+  * [Jeremy Soller on Twitter](https://twitter.com/jeremy_soller/status/1577078732581269505 "Jeremy Soller on Twitter")
+  * [Jeremy Soller on Twitter](https://twitter.com/jeremy_soller/status/1576682150836830208 "Jeremy Soller on Twitter")
+  * [Jeremy Soller on Twitter](https://twitter.com/jeremy_soller/status/1577830531554676736 "Jeremy Soller on Twitter")
+  * [Checklist of things going into Iced for Cosmic](https://github.com/pop-os/libcosmic/pull/12 "Checklist of things going into Iced for Cosmic")
+  * [Acastus](http://github.com/gjedeer/Acastus "Acastus") — Acastus Photon is a completely private, free and open source Address / POI lookup application for android.
+  * [photon.komoot.io](http://photon.komoot.io/ "photon.komoot.io") — Search as you type with OpenStreetMap
+  * [pelias.io](http://pelias.io/ "pelias.io")
+  * [Auto Move Windows - GNOME Shell Extensions](https://extensions.gnome.org/extension/16/auto-move-windows/ "Auto Move Windows - GNOME Shell Extensions")
+  * [Podcasting 2.0 Apps](https://podcastindex.org/apps?appTypes=app&elements=Value "Podcasting 2.0 Apps")
+
+

--- a/content/show/office-hours/0014.md
+++ b/content/show/office-hours/0014.md
@@ -1,0 +1,149 @@
+{
+  "type": "episode",
+  "draft": false,
+  "show_slug": "office-hours",
+  "show_name": "Office Hours",
+  "episode": 14,
+  "episode_padded": "0014",
+  "episode_guid": "617a5052-0149-4d6c-8d1c-54bffee38c96",
+  "slug": "14",
+  "title": "Debian Downer",
+  "description": "It was one technical disaster after another, we recap the series of technical challenges that killed all future shows from the road.",
+  "date": "2022-10-14T03:00:00-07:00",
+  "header_image": "/images/shows/office-hours.png",
+  "categories": [
+    "Office Hours"
+  ],
+  "tags": [
+    "alby",
+    "chrislas",
+    "fountain",
+    "geocaching",
+    "hacktoberfest",
+    "hugo",
+    "infrastructure as code",
+    "jupiter broadcasting",
+    "new show name",
+    "office hours",
+    "podverse",
+    "road shows",
+    "road trip",
+    "rust desk",
+    "rv podcasting",
+    "sonobus",
+    "technical failure",
+    "value for value"
+  ],
+  "hosts": [
+    "chris",
+    "brent"
+  ],
+  "guests": [],
+  "sponsors": [
+    "linode.com-oh",
+    "newpodcastapps.com-oh",
+    "jupiter.party-oh"
+  ],
+  "podcast_duration": "01:03:23",
+  "podcast_file": "https://aphid.fireside.fm/d/1437767933/5359b045-c3ec-4bb4-8e0d-5d98a374de56/617a5052-0149-4d6c-8d1c-54bffee38c96.mp3",
+  "podcast_bytes": 53246400,
+  "podcast_chapters": {
+    "version": "1.1.0",
+    "chapters": [
+      {
+        "startTime": 0,
+        "title": "Maybe We Should Just Quit",
+        "img": null,
+        "url": null,
+        "toc": null,
+        "endTime": null,
+        "location": null
+      },
+      {
+        "startTime": 148,
+        "title": "Intro",
+        "img": null,
+        "url": null,
+        "toc": null,
+        "endTime": null,
+        "location": null
+      },
+      {
+        "startTime": 348,
+        "title": "Denouement",
+        "img": null,
+        "url": null,
+        "toc": null,
+        "endTime": null,
+        "location": null
+      },
+      {
+        "startTime": 1813,
+        "title": "Shotgun Commits",
+        "img": null,
+        "url": null,
+        "toc": null,
+        "endTime": null,
+        "location": null
+      },
+      {
+        "startTime": 2157,
+        "title": "Calling All Hackers",
+        "img": null,
+        "url": null,
+        "toc": null,
+        "endTime": null,
+        "location": null
+      },
+      {
+        "startTime": 2521,
+        "title": "Boosts",
+        "img": null,
+        "url": null,
+        "toc": null,
+        "endTime": null,
+        "location": null
+      },
+      {
+        "startTime": 3774,
+        "title": "Outro",
+        "img": null,
+        "url": null,
+        "toc": null,
+        "endTime": null,
+        "location": null
+      }
+    ],
+    "author": "Chris Fisher",
+    "title": "14: Debian Downer",
+    "podcastName": "Office Hours",
+    "description": null,
+    "fileName": null,
+    "waypoints": null
+  },
+  "podcast_alt_file": null,
+  "podcast_ogg_file": null,
+  "video_file": null,
+  "video_hd_file": null,
+  "video_mobile_file": null,
+  "youtube_link": null,
+  "jb_url": null,
+  "fireside_url": "/14"
+}
+
+
+### Episode Links
+
+  * [podcast.ai](https://podcast.ai/ "podcast.ai") — Joe Rogan interviews Steve Jobs
+  * [RustDesk](https://rustdesk.com/ "RustDesk") — A remote desktop software, the open source TeamViewer alternative, works out of the box, no configuration required. 
+  * [Self-Hosted](https://selfhosted.show/ "Self-Hosted") — Self-Hosted is a chat show between Chris and Alex two long-time "self-hosters" who share their lessons and take you along for the journey as they learn new ones.
+  * [Try Infrastructure as Code eBook](https://www.linode.com/content/try-infrastructure-as-code-ebook-series/?utm_campaign=eBook+%7C+Try+IaC&utm_medium=social&utm_source=twitter "Try Infrastructure as Code eBook") — This 200+ page ebook is meant to be a step-by-step guide for you to learn how to use some of the most in-demand IaC tools that exist
+  * [Hacktoberfest 2022](https://hacktoberfest.com/ "Hacktoberfest 2022")
+  * [JB & Hacktoberfest - Let's participate!](https://github.com/JupiterBroadcasting/jupiterbroadcasting.com/issues/457 "JB & Hacktoberfest - Let's participate!") — It would be cool if JB would add the "hacktoberfest" tag to this repo so contributors can get credit for submitting PRs for Hacktoberfest! 
+  * [Feature/automate sponsors page by ChanceM](https://github.com/JupiterBroadcasting/jupiterbroadcasting.com/pull/451 "Feature/automate sponsors page by ChanceM")
+  * [Great Example: Deploy Previews and URL Encoding Tags by elreydetoda · Pull Request #456](https://github.com/JupiterBroadcasting/jupiterbroadcasting.com/pull/456 "Great Example: Deploy Previews and URL Encoding Tags by elreydetoda · Pull Request #456")
+  * [Fountain 0.4.9](https://fountainpodcasts.substack.com/p/fountain-0-4-9 "Fountain 0.4.9") — Introducing a new earnings system to replace Flow, plus an improved referrals system that means you will be stacking sats in your sleep!
+  * [Fountain 0.5.2](https://fountainpodcasts.substack.com/p/fountain-052-android-auto-and-bug?utm_source=post-email-title&publication_id=1076421&post_id=77552335&isFreemail=true&utm_medium=email "Fountain 0.5.2") — Android users can now play their podcasts and discover new shows while they are driving.
+  * [Grab a new Podcast App](https://podcastindex.org/apps?appTypes=app&elements=Value "Grab a new Podcast App") — Upgrade to a Podcasting 2.0 compatible app and send a Boost into the show.
+
+


### PR DESCRIPTION
* Adds `.fleet` folder to gitignore

I also think once Fleet is out of the public preview, we can talk about potentially adding their `run.json` configuration file to project to run the make commands.