### PR TITLE
Add the show name to the episode page titles

### DIFF
--- a/themes/jb/layouts/partials/meta.html
+++ b/themes/jb/layouts/partials/meta.html
@@ -1,9 +1,22 @@
-<!-- Meta Ttitles -->
-<title itemprop="name">{{ .Title -}}{{- if .Title }} | {{end}}{{ .Site.Title }}</title>
-<meta property="og:title" content="{{ .Title -}}{{- if .Title }} | {{end}}{{ .Site.Title }}" />
-<meta name="twitter:title" content="{{ .Title -}}{{- if .Title }} | {{end}}{{ .Site.Title }}" />
-<meta itemprop="name" content="{{ .Title -}}{{- if .Title }} | {{end}}{{ .Site.Title }}" />
-<meta name="application-name" content="{{ .Title -}}{{- if .Title }} | {{end}}{{ .Site.Title }}" />
+<!-- Meta Titles -->
+{{- $titleMeta := .Site.Title -}}
+{{- if .Title -}}
+    {{ if and 
+        (and (isset .Params `show_name`) (isset .Params `episode`)) 
+        (ne .Title (print .CurrentSection.Title ` ` .Params.episode))
+    -}}
+        {{/* for all other shows */ -}}
+        {{- $titleMeta = (printf `%s | %s %v | %s` .Params.show_name .Title .Params.episode .Site.Title) -}}
+    {{ else -}}
+        {{/* covers LAN and any page that does not have a show name or episode */ -}}
+        {{- $titleMeta = (printf `%s | %s` .Title .Site.Title) -}}
+    {{ end -}}
+{{ end -}}
+<title itemprop="name">{{ $titleMeta }}</title>
+<meta property="og:title" content="{{ $titleMeta }}" />
+<meta name="twitter:title" content="{{ $titleMeta }}" />
+<meta itemprop="name" content="{{ $titleMeta }}" />
+<meta name="application-name" content="{{ $titleMeta }}" />
 <meta property="og:site_name" content="{{ .Site.Title }}" />
 
 <!-- Meta Description -->

--- a/themes/jb/layouts/partials/meta.html
+++ b/themes/jb/layouts/partials/meta.html
@@ -6,7 +6,7 @@
         (ne .Title (print .CurrentSection.Title ` ` .Params.episode))
     -}}
         {{/* for all other shows */ -}}
-        {{- $titleMeta = (printf `%s | %s %v | %s` .Params.show_name .Title .Params.episode .Site.Title) -}}
+        {{- $titleMeta = (printf `%s | %s %v | %s` .Title .Params.show_name .Params.episode .Site.Title) -}}
     {{ else -}}
         {{/* covers LAN and any page that does not have a show name or episode */ -}}
         {{- $titleMeta = (printf `%s | %s` .Title .Site.Title) -}}


### PR DESCRIPTION
Fixes #459

As I understood it, this change required changing the page meta's Title properties, as well as any related properties. I understood "related properties" here to mean, effectively, any properties that had the same template syntax within the `meta.html` partial.

To address LAN, I copied the same conditional applied in #74.

Finally, I had to change the `" "` used in the `print` function call to use backticks to avoid a collision with some of the template properties that were using double quotes.

Thanks for participating in Hacktoberfest!

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>