### PR TITLE
Added actions status badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # JupiterBroadcasting.com, et al. Websites
 
+![Test Status](https://github.com/JupiterBroadcasting/jupiterbroadcasting.com/actions/workflows/e2e.yml/badge.svg) ![Deploy Status](https://github.com/JupiterBroadcasting/jupiterbroadcasting.com/actions/workflows/deploy-prod.yml/badge.svg) ![Scraping Status](https://github.com/JupiterBroadcasting/jupiterbroadcasting.com/actions/workflows/scrape.yml/badge.svg) 
+
 ## Repo here includes issue tracking for:
   * [JupiterBroadcasting.com](https://jupiterbroadcasting.com)
   * [LINUX Unplugged](https://linuxunplugged.com/)
@@ -36,9 +38,9 @@ This will build the site (all 28000+ pages) and takes anywhere from 30s - 5 minu
 
 #### Deployment
 
-Deployment is done with Github Actions, see workflow file in `.github/workflows/main.yml`
+Deployment is done with Github Actions, see workflow file in `.github/workflows/deploy-prod.yml`
 At the moment it is only triggered when something in the `main` branch is changing, but it can also be set up to run at certain times.
-This would also enable scheduled publishing, since Hugo per default only builds pages which have set `date` in frontmatter to <= `now`
+This would also enable scheduled publishing, since Hugo per default only builds pages which have set `date` in frontmatter to <= `now`.
 
 ### Credits
 


### PR DESCRIPTION
I'm back with another attention grabbing improvement to your READMEs :-)

This shows at-a-glance badges to show the current status of actions.

![image](https://user-images.githubusercontent.com/178003/197309149-ad74f170-6b01-4022-86e7-b92a2ade0bd4.png)

Also fixed a broken path in the docs referencing the GH actions.yml