### PR TITLE
Periodic Matrix Federation testing

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run your tests
         working-directory: ./test/
         # https://github.com/actions/runner/issues/241#issuecomment-577360161
-        run: script -e -c "docker-compose exec testing pytest -m "not periodic" --base-url http://jb-com --junitxml report.xml"
+        run: script -e -c "docker-compose exec testing pytest -m 'not periodic' --base-url http://jb-com --junitxml report.xml"
 
       - name: Save screenshots
         uses: actions/upload-artifact@v2

--- a/.github/workflows/periodic_test.yml
+++ b/.github/workflows/periodic_test.yml
@@ -1,17 +1,12 @@
-name: E2E Tests
+name: Periodic Tests
 
 on:
-
-  pull_request:
-  push:
-    branches:
-      - main
-      - develop
-  # Allows you to run this workflow manually from the Actions tab
+  schedule:
+    - 0 0 * * 0 # Weekly (At 00:00 on Sunday)
   workflow_dispatch:
 
 jobs:
-  e2e-tests:
+  periodic-tests:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,19 +25,12 @@ jobs:
       - name: Run your tests
         working-directory: ./test/
         # https://github.com/actions/runner/issues/241#issuecomment-577360161
-        run: script -e -c "docker-compose exec testing pytest -m "not periodic" --base-url http://jb-com --junitxml report.xml"
-
-      - name: Save screenshots
-        uses: actions/upload-artifact@v2
-        with:
-          name: screenshots
-          path: screenshots/
+        run: script -e -c "docker-compose exec testing pytest -m periodic --base-url http://jb-com --junitxml report.xml"
 
       - name: Publish Test Report
         uses: dorny/test-reporter@v1
         # TODO: potential solution in the future: https://stackoverflow.com/a/70448851
-        if: always() && github.event_name != 'pull_request'
         with:
-          name: E2E Tests
+          name: Periodic Tests
           path: './report.xml'
           reporter: java-junit

--- a/.github/workflows/periodic_test.yml
+++ b/.github/workflows/periodic_test.yml
@@ -2,7 +2,7 @@ name: Periodic Tests
 
 on:
   schedule:
-    - 0 0 * * 0 # Weekly (At 00:00 on Sunday)
+      - 0 12 * * 0 # Noon on Sunday UTC
   workflow_dispatch:
 
 jobs:
@@ -29,7 +29,6 @@ jobs:
 
       - name: Publish Test Report
         uses: dorny/test-reporter@v1
-        # TODO: potential solution in the future: https://stackoverflow.com/a/70448851
         with:
           name: Periodic Tests
           path: './report.xml'

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -4,7 +4,7 @@ FROM mcr.microsoft.com/playwright/python:v1.25.2-jammy
 
 RUN pip install pipenv
 
-CMD [ "--base-url", "http://localhost:1313" ]
+CMD [ "--base-url", "http://localhost:1313", "-m", "not periodic" ]
 ENTRYPOINT [ "pytest" ]
 
 COPY test/Pipfile test/Pipfile.lock ./

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JupiterBroadcasting.com, et al. Websites
 
-![Test Status](https://github.com/JupiterBroadcasting/jupiterbroadcasting.com/actions/workflows/e2e.yml/badge.svg) ![Deploy Status](https://github.com/JupiterBroadcasting/jupiterbroadcasting.com/actions/workflows/deploy-prod.yml/badge.svg) ![Scraping Status](https://github.com/JupiterBroadcasting/jupiterbroadcasting.com/actions/workflows/scrape.yml/badge.svg) 
+![E2E Status](https://github.com/JupiterBroadcasting/jupiterbroadcasting.com/actions/workflows/e2e.yml/badge.svg) ![Periodic Test Status](https://github.com/JupiterBroadcasting/jupiterbroadcasting.com/actions/workflows/periodic_test.yml/badge.svg) ![Deploy Status](https://github.com/JupiterBroadcasting/jupiterbroadcasting.com/actions/workflows/deploy-prod.yml/badge.svg) ![Scraping Status](https://github.com/JupiterBroadcasting/jupiterbroadcasting.com/actions/workflows/scrape.yml/badge.svg) 
 
 ## Repo here includes issue tracking for:
   * [JupiterBroadcasting.com](https://jupiterbroadcasting.com)

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,4 +5,5 @@ python_functions = test_*
 addopts = -ra -v
 testpaths = test
 markers =
-    dev: the current test(s) you're working on for developing
+    dev: "the current test(s) you're working on for developing"
+    periodic: "tests that need to run on a schedule instead of running when a PR is made"

--- a/test/external/test_matrix.py
+++ b/test/external/test_matrix.py
@@ -1,0 +1,8 @@
+from pytest import mark
+from playwright.sync_api import APIRequestContext
+
+
+@mark.periodic
+def test_matrix_federation(api_request_context: APIRequestContext):
+    response = api_request_context.get("https://federationtester.matrix.org/api/report?server_name=jupiterbroadcasting.com")
+    assert response.json()["FederationOK"] == True

--- a/test/external/test_matrix.py
+++ b/test/external/test_matrix.py
@@ -5,4 +5,6 @@ from playwright.sync_api import APIRequestContext
 @mark.periodic
 def test_matrix_federation(api_request_context: APIRequestContext):
     response = api_request_context.get("https://federationtester.matrix.org/api/report?server_name=jupiterbroadcasting.com")
-    assert response.json()["FederationOK"] == True
+    assert response.ok, "API did not return a response code of 200-299"
+    assert response.body() != "", "API did not return any data"
+    assert response.json()["FederationOK"] == True, "Federation is not okay"


### PR DESCRIPTION
Fixes #438

* Add test for checking `FederationOK` is `true` with [matrix federation tester api](https://federationtester.matrix.org/)
* Add a pytest mark to make tests be able to run periodically
* Add Action to run tests marked as periodic weekly.
* Update E2E action to ignore tests marked as periodic
* Add periodic tests badge to README for quick status reference