### PR TITLE
E2E Test Expansion

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,14 +1,15 @@
-
 from pathlib import Path
-from typing import Dict, Generator, List, Tuple, Callable
+from typing import Generator, Callable
 from pytest import fixture
 from _pytest.fixtures import SubRequest
 from pytest_base_url.plugin import base_url
 from playwright.sync_api import Playwright, APIRequestContext, Route, Page, Browser
 
+
 @fixture
 def get_test_dir() -> Path:
     return Path(__file__).parent.absolute()
+
 
 @fixture
 def screenshot_dir() -> Path:
@@ -37,17 +38,30 @@ jq '. | keys' devices.json| less
     ]
 )
 def mobile_device_tuple(
-    # how to access the params
-    request: SubRequest,
-    # browser object given by playwright built-in fixture
-    browser: Browser,
-    # Playwright object given by playwright built-in fixture
-    playwright: Playwright,
-    # from the pytest-base-url plugin Playwright installs (automatically)
-    #   so we're not having to hard-code the URL
-    base_url: base_url,
-) -> Tuple[Page,str]:
-    
+        # how to access the params
+        request: SubRequest,
+        # browser object given by playwright built-in fixture
+        browser: Browser,
+        # Playwright object given by playwright built-in fixture
+        playwright: Playwright,
+        # from the pytest-base-url plugin Playwright installs (automatically)
+        #   so we're not having to hard-code the URL
+        base_url: base_url,
+) -> tuple[Page, str]:
+    """
+    identified all possible device types by running the following in a python interpreter + shell commands
+
+    # python interpreter
+    with sync_playwright() as playwright:
+        Path('./devices.json').write_text(j_dumps(playwright.devices, indent=2))
+
+    # shell cmd
+    jq '. | keys' devices.json| less
+
+    also should be able to view them here:
+    https://github.com/microsoft/playwright/blob/v1.25.2/packages/playwright-core/src/server/deviceDescriptorsSource.json
+    """
+
     # based on here: https://playwright.dev/python/docs/emulation#devices
     context = browser.new_context(
         base_url=base_url,
@@ -56,26 +70,26 @@ def mobile_device_tuple(
     )
     try:
         # essentially a "return", but used with generators
-        yield (context.new_page(), request.param)
-    except Exception as excpt:
-        raise excpt
+        yield context.new_page(), request.param
+    except Exception as e:
+        raise e
     finally:
-        # supposed to get rid of coookies/other stored info after generator is done
+        # supposed to get rid of cookies/other stored info after generator is done
         # https://playwright.dev/python/docs/api/class-apirequestcontext#api-request-context-dispose
         # https://github.com/microsoft/playwright.dev/blob/d9b4a2f3bd0510ea89c87ed230b8241eb33b6688/python/docs/api-testing.mdx#writing-api-test
         context.close()
 
-# https://playwright.dev/python/docs/api-testing#configure
-# used for doing similar requests to API calls
+
 @fixture(scope="session")
 def api_request_context(
-    # base playwright context/object
-    playwright: Playwright,
-    # from the pytest-base-url plugin Playwright installs (automatically)
-    #   so we're not having to hard-code the URL
-    base_url: base_url,
-    # Generator is returned based on Playwright docs
-) -> Generator[APIRequestContext, None, None]:
+        playwright: Playwright,  # base playwright context/object
+        # From the pytest-base-url plugin Playwright installs (automatically) so we're not having to hard-code the URL
+        base_url: base_url,
+) -> Generator[APIRequestContext, None, None]:  # Generator is returned based on Playwright docs
+    """
+    https://playwright.dev/python/docs/api-testing#configure
+    used for doing similar requests to API calls
+    """
     # creates APIRequestContext to allow requests to be made
     #   using the base_url variable (from the plugin) to define
     #   the base_url which'll allow requests relative to that base_url
@@ -87,21 +101,23 @@ def api_request_context(
     # https://github.com/microsoft/playwright.dev/blob/d9b4a2f3bd0510ea89c87ed230b8241eb33b6688/python/docs/api-testing.mdx#writing-api-test
     request_context.dispose()
 
-@fixture
-def expected_rss_feeds() -> List[Dict[str,str,]]:
-    return [
-        { 'href': 'http://feeds2.feedburner.com/JupiterBroadcasting', 'title': 'All Shows Feed - Audio'},
-        { 'href': 'http://feeds2.feedburner.com/AllJupiterVideos', 'title': 'All Shows Feed - Video'},
-        { 'href': 'https://coder.show/rss', 'title': 'Coder Radio'},
-        { 'href': 'https://extras.show/rss', 'title': 'Jupiter EXTRAS'},
-        { 'href': 'https://linuxactionnews.com/rss', 'title': 'Linux Action News'},
-        { 'href': 'https://linuxunplugged.com/rss', 'title': 'LINUX Unplugged'},
-        { 'href': 'https://www.officehours.hair/rss', 'title': 'Office Hours'},
-        { 'href': 'https://selfhosted.show/rss', 'title': 'Self-Hosted'}
-    ]
 
 @fixture
-def expected_dropdown_items() -> Dict[str,List[Dict[str,str]]]:
+def expected_rss_feeds() -> list[dict[str, str, ]]:
+    return [
+        {'href': 'http://feeds2.feedburner.com/JupiterBroadcasting', 'title': 'All Shows Feed - Audio'},
+        {'href': 'http://feeds2.feedburner.com/AllJupiterVideos', 'title': 'All Shows Feed - Video'},
+        {'href': 'https://coder.show/rss', 'title': 'Coder Radio'},
+        {'href': 'https://extras.show/rss', 'title': 'Jupiter EXTRAS'},
+        {'href': 'https://linuxactionnews.com/rss', 'title': 'Linux Action News'},
+        {'href': 'https://linuxunplugged.com/rss', 'title': 'LINUX Unplugged'},
+        {'href': 'https://www.officehours.hair/rss', 'title': 'Office Hours'},
+        {'href': 'https://selfhosted.show/rss', 'title': 'Self-Hosted'}
+    ]
+
+
+@fixture
+def expected_dropdown_items() -> dict[str, list[dict[str, str]]]:
     return {
         "Shows": [
             {'href': '/show/coder-radio/', 'title': 'Coder Radio'},
@@ -130,16 +146,18 @@ def expected_dropdown_items() -> Dict[str,List[Dict[str,str]]]:
         ]
     }
 
+
 @fixture
-def expected_dropdowns() -> List[Dict[str,str]]:
+def expected_dropdowns() -> list[dict[str, str]]:
     return [
         {'title': 'Shows', 'href': '/show/'},
         {'title': 'People', 'href': "/people/"},
         {'title': 'Community', 'href': "/community/"}
     ]
 
+
 @fixture
-def expect_nav_items() -> List[Dict[str,str]]:
+def expect_nav_items() -> list[dict[str, str]]:
     return [
         {'title': 'Sponsors', 'href': '/sponsors/'},
         {'title': 'Live', 'href': '/live/'},
@@ -149,18 +167,22 @@ def expect_nav_items() -> List[Dict[str,str]]:
         {'title': 'Membership', 'href': '/membership/'},
         # commenting out for now PR #399
         # {'title': 'Archive', 'href': '/archive'},
-        # failing on tests here: https://github.com/JupiterBroadcasting/jupiterbroadcasting.com/runs/8254156209?check_suite_focus=true#step:9:26
+        # failing on tests here:
+        # https://github.com/JupiterBroadcasting/jupiterbroadcasting.com/runs/8254156209?check_suite_focus=true#step:9:26
         {'title': 'Contact', 'href': '/contact/'},
     ]
+
 
 @fixture
 def get_live_event(get_test_dir: Path) -> str:
     return Path(get_test_dir / 'fixture_files/jb-live_sample-live-event.json').read_text()
 
+
 @fixture
-def set_live(get_live_event: str) -> Tuple[Callable, str]:
-    return (_replace_live_event,get_live_event)
-    # return replace_live_event
+def set_live(get_live_event: str) -> tuple[Callable, str]:
+    return _replace_live_event, get_live_event
+# return replace_live_event
+
 
 @staticmethod
 def _replace_live_event(page: Page, live_event: str) -> None:

--- a/test/e2e/test_404.py
+++ b/test/e2e/test_404.py
@@ -1,0 +1,21 @@
+from pytest import fixture
+from playwright.sync_api import Page, expect
+
+
+@fixture(autouse=True)
+def setup(page: Page):
+    """
+    Code here will run for every test in this file
+    """
+    page.goto("/404.html")  # TODO: Change to random address once #483 is merged
+
+
+def test_404_contents(page: Page):
+    """
+    Ensure text "Page Not Found" and unicorn image is present on the 404 page
+    """
+    title = page.locator(".title.has-text-centered")
+    expect(title).to_contain_text("Page Not Found")
+
+    unicorn = page.locator("#img-404")
+    expect(unicorn).to_be_visible()

--- a/test/e2e/test_calendar.py
+++ b/test/e2e/test_calendar.py
@@ -1,0 +1,11 @@
+from pytest import fixture
+from playwright.sync_api import Page, expect, FrameLocator, Locator
+
+
+@fixture(autouse=True)
+def setup(page: Page):
+    """
+    Code here will run for every test in this file
+    """
+    page.goto("/calendar")
+    page.wait_for_load_state("networkidle")

--- a/test/e2e/test_contact.py
+++ b/test/e2e/test_contact.py
@@ -1,26 +1,28 @@
 from pathlib import Path
+from pytest import fixture
 from playwright.sync_api import Page, FrameLocator, Locator
 
-"""
-Take a screenshot of the contact page for manual review
-"""
-def test_contact_screenshot(page: Page, screenshot_dir: Path):
-    page.goto("/contact", wait_until="networkidle")
-    page.screenshot(path=f"{screenshot_dir}/contact.png", full_page=True)
 
-"""
-This test ensures that the "Submit" button at the bottom of the contact form is always visible to the user, even if they forget the fill in the fields. This
-test also saves a screenshot of the contact page after the form validation errors have been generated for manual review if needed.
-
-Steps:
-  1. Go to contact page
-  2. Click "Submit" button without filling out any data
-  3. Get the height of the iframe (defined as an html attribute) and adds it to the distance from the top of the screen to the top of the iframe
-  4. Measure the height of the top of the screen to the bottom of the "Submit" button
-  5. Pass if the distance from the bottom of the iframe is greater than the distance to the bottom of the button in the iframe (ie. the button can be seen)
-"""
-def test_submit_button_visible(page: Page, screenshot_dir: Path):
+@fixture(autouse=True)
+def setup(page: Page):
+    """
+    Code here will run for every test in this file
+    """
     page.goto("/contact")
+
+
+def test_submit_button_visible(page: Page, screenshot_dir: Path):
+    """
+    This test ensures that the "Submit" button at the bottom of the contact form is always visible to the user, even if they forget the fill in the fields. This
+    test also saves a screenshot of the contact page after the form validation errors have been generated for manual review if needed.
+
+    Steps:
+      1. Go to contact page
+      2. Click "Submit" button without filling out any data
+      3. Get the height of the iframe (defined as an html attribute) and adds it to the distance from the top of the screen to the top of the iframe
+      4. Measure the height of the top of the screen to the bottom of the "Submit" button
+      5. Pass if the distance from the bottom of the iframe is greater than the distance to the bottom of the button in the iframe (ie. the button can be seen)
+    """
     contact_form: FrameLocator = page.frame_locator('#contact-frame')
     submit_button: Locator = contact_form.locator("#saveForm")
 
@@ -30,14 +32,14 @@ def test_submit_button_visible(page: Page, screenshot_dir: Path):
     page.locator("h1").scroll_into_view_if_needed()
 
     # This test assumes the iframe will always be rendered, if the test fails here, the iframe is missing
-    frame_height: float = float(page.locator("#contact-frame").get_attribute("height")) + page.locator(selector="#contact-frame").bounding_box().get("y")
+    frame_height: float = float(page.locator("#contact-frame").get_attribute("height")) + \
+        page.locator(selector="#contact-frame").bounding_box().get("y")
 
-    # This is just a precautionary measure to ensure the submit button is on the screen it'll return None if it's not, and since here are more places that
-    # use the value from the bounding_box's return ensuring it's not None
+    # This is just a precautionary measure to ensure the submit button is on the screen it'll return None if it's not,
+    # and since here are more places use the value from the bounding_box's return ensuring it's not None
     button_location: dict = submit_button.bounding_box()
     if button_location is None:
         assert False, "Submit Button is hidden"
     button_bottom: float = button_location.get("y") + button_location.get("height")
 
-    page.screenshot(path=f"{screenshot_dir}/contact_errors.png", full_page=True)
     assert button_bottom <= frame_height, "Form content is running off the iframe"

--- a/test/e2e/test_edge-cases.py
+++ b/test/e2e/test_edge-cases.py
@@ -1,9 +1,0 @@
-from playwright.sync_api import Page, expect
-
-"""
-Checking for broken tag links with spaces in them
-"""
-def test_tag_broken_link_spaces(page: Page):
-    page.goto("/show/linux-unplugged/489/")
-    page.locator(".tag > a", has_text="linux unplugged").click()
-    expect(page.locator(".title", has_text="Tag: linux unplugged")).to_be_visible()

--- a/test/e2e/test_episode.py
+++ b/test/e2e/test_episode.py
@@ -1,0 +1,89 @@
+import os
+import re
+
+from pytest import fixture, mark
+from playwright.sync_api import Page, FrameLocator, expect
+
+
+"""
+Dictionary of episodes that contain known edge cases
+"""
+EXTRA_EPISODES: list[dict[str, str]] = [
+    {  # 3 Hosts and 3 Guests
+        "show": "linux-unplugged",
+        "number": "434"
+    },
+    {  # No Sponsor
+        "show": "coder-radio",
+        "number": "343"
+    }
+]
+
+
+@fixture()
+def episodes() -> list[str]:
+    """
+    Generate list of episode URLS for testing. This list consists of the following
+    * For each show:
+        * 5 oldest episodes
+        * 5 newest episodes
+    * A specified set of episodes that contain "out of the ordinary" things for an episode (an example being a high number of guests
+    """
+    test_episodes: list[str] = []
+    shows_dir: str = "content/show"
+    meta_files: [str] = ["_index.md", "subscribe.md"]
+
+    # Fist and last 5 episodes for each show
+    for show in os.listdir(shows_dir):
+        show_url: str = f"/show/{show}"
+        all_episodes: list[str] = [e for e in os.listdir(f"{shows_dir}/{show}") if os.path.isfile(f"{shows_dir}/{show}/{e}") and e not in meta_files]
+        all_episodes.sort()
+
+        test_episodes += [f"{show_url}/{os.path.splitext(e)[0].lstrip('0') or '0'}" for e in all_episodes[:5:] if e not in test_episodes]  # First 5 episodes of a show
+        test_episodes += [f"{show_url}/{os.path.splitext(e)[0].lstrip('0') or '0'}" for e in all_episodes[-5::] if e not in test_episodes]  # 5 most recent episodes of a show
+
+    # Defined list of edge case episodes
+    test_episodes += [f"/show/{e['show']}/{e['number']}" for e in EXTRA_EPISODES if e not in test_episodes]
+
+    return test_episodes
+
+
+@mark.dev
+def test_page_title(page: Page, episodes: list[str]):
+    """
+    Make sure the title (text in the tab) contains the show name, episode number, and
+    network name (Jupiter Broadcasting)
+    """
+    # TODO figure out how to call this loop async
+    for url in episodes:
+        show, episode_number = url.split('/')[2:4] # This skips the empty string and 'show' in the url
+        page.goto(url)
+        print(f"{show} - {episode_number}")
+        expect(page).to_have_title(re.compile(f".* | {show} {episode_number} | Jupiter Broadcasting"))
+
+
+def test_podverse_player(page: Page, episodes: list[str]):
+    """
+    Test podverse player to and make sure the correct show is displayed
+    """
+    def check_title(page: Page, url: str):
+        show, episode_number = url.split('/')[2:4]  # This skips the empty string and 'show' in the url
+        page.goto(url)
+        pv_player: FrameLocator = page.frame_locator("#pv-embed-player")
+        # expect(pv_player).to_be_visible()
+        pv_player_show_text: str = pv_player.locator(".embed-player-header-top-text").text_content()
+        assert pv_player_show_text.replace('-', ' ').lower() == show.replace('-', ' ').lower(), \
+            f"Podverse player show for {url} says {pv_player_show_text}"
+
+    # TODO figure out how to call this loop async
+    for url in episodes:
+        check_title(page, url)
+
+
+def test_tag_broken_link_spaces(page: Page):
+    """
+    Checking for broken tag links with spaces in them
+    """
+    page.goto("/show/linux-unplugged/489/")
+    page.locator(".tag > a", has_text="linux unplugged").click()
+    expect(page.locator(".title", has_text="Tag: linux unplugged")).to_be_visible()

--- a/test/e2e/test_home.py
+++ b/test/e2e/test_home.py
@@ -1,27 +1,34 @@
-import re
-from pathlib import Path
 from typing import Dict, List
 from urllib.parse import urlparse
 from pytest import fixture, mark
 from playwright.sync_api import Page, expect, Locator
 
-# allows this to be run for every test in this file,
-#   without it needing to specify it
+
 @fixture(autouse=True)
 def setup(page: Page):
+    """
+    Code here will run for every test in this file
+    """
     page.goto("/")
 
-def test_homepage_screenshot(page: Page, screenshot_dir: Path):
-    page.screenshot(path=f"{screenshot_dir}/home.png", full_page=True)
 
 def test_homepage_has_logo(page: Page):
+    """
+    Ensure the large logo and text underneath it is visible on the screen
+    """
     logo = page.locator(".logo")
     expect(logo).to_be_visible()
 
     logo_subtitle = page.locator('.subtitle')
-    expect(logo_subtitle).to_contain_text('Home to the best shows on Linux, Open Source, Security, Privacy, Community, Development, and News')
+    expect(logo_subtitle).to_contain_text(
+        'Home to the best shows on Linux, Open Source, Security, Privacy, Community, Development, and News'
+    )
+
 
 def test_pagination(page: Page):
+    """
+    Ensure the pagination loads different episodes
+    """
     first_card = page.locator('.card').nth(0).text_content
     page_2_button = page.locator('[aria-label="pagination"] >> text=2')
     page_2_button.click()
@@ -30,15 +37,22 @@ def test_pagination(page: Page):
     first_card_second_page = page.locator('.card').nth(0).text_content
     assert first_card != first_card_second_page
 
-def test_rss_feeds(page: Page, expected_rss_feeds: List[Dict[str,str]]):
+
+def test_rss_feeds(page: Page, expected_rss_feeds: List[Dict[str, str]]):
+    """
+    Ensure the RSS feeds menu contains all the fields specified in the conftest file
+    """
     for rss_feed in expected_rss_feeds:
         element = page.locator('#rss-feeds-menu > div > a[href^="{}"]'.format(rss_feed['href']))
         expect(element).to_contain_text(rss_feed['title'])
 
 
-def test_dropdowns(page: Page, expected_dropdown_items: Dict[str,List[Dict[str,str]]]):
+def test_dropdowns(page: Page, expected_dropdown_items: Dict[str, List[Dict[str, str]]]):
+    """
+    Tests dropdowns to make sure the dropdown items have links, and all items specified in conftest are present
+    """
     for dropdown_text, child_elements in expected_dropdown_items.items():
-        
+
         # dropdown item to hover over in menu
         parent_element: Locator = page.locator(f'.navbar-start >> a:has-text("{dropdown_text}"):visible')
 
@@ -65,9 +79,10 @@ def test_dropdowns(page: Page, expected_dropdown_items: Dict[str,List[Dict[str,s
             expect(item).to_be_visible()
 
 
-
 def test_nav(page: Page, expected_dropdowns, expect_nav_items):
-
+    """
+    Test main navigation items
+    """
     nav = page.locator('#mainnavigation')
     expect(nav).to_be_visible()
     dropdown_nav_items = page.locator('.navbar-start > * > a')
@@ -75,7 +90,6 @@ def test_nav(page: Page, expected_dropdowns, expect_nav_items):
     for i in range(count):
         expect(dropdown_nav_items.nth(i)).to_contain_text(expected_dropdowns[i]['title'])
         expect(dropdown_nav_items.nth(i)).to_have_attribute('href', expected_dropdowns[i]['href'])
-
 
     nav_items = page.locator('.navbar-start > a')
     count = nav_items.count()

--- a/test/e2e/test_infra_configs.py
+++ b/test/e2e/test_infra_configs.py
@@ -4,6 +4,10 @@ from playwright.sync_api import APIRequestContext
 def test_matrix_well_known(
     api_request_context: APIRequestContext,
 ):
+    """
+    Check to make sure the files required for matrix federation and name resolution
+    are present and contain necessary details
+    """
     well_known_folder = "/.well-known/matrix"
     well_known_types = {
         "client": {

--- a/test/e2e/test_live.py
+++ b/test/e2e/test_live.py
@@ -4,9 +4,8 @@ from playwright.sync_api import Page, expect, Locator, FrameLocator
 
 
 def test_live_indicator(
-    page: Page,
-    set_live: Tuple[Callable, str],
-    screenshot_dir: Path,
+        page: Page,
+        set_live: Tuple[Callable, str]
 ):
     # explicitly defining tuple objects for clarity
     replace_live_event: Callable = set_live[0]
@@ -19,7 +18,7 @@ def test_live_indicator(
     page.goto("/live")
 
     # validate live button is red
-    expect(page.locator("#mainnavigation.is-live").locator("#livebutton"),).to_have_css(
+    expect(page.locator("#mainnavigation.is-live").locator("#livebutton")).to_have_css(
         name="background-color",
         value="rgb(255, 0, 0)",  # red
     )
@@ -31,13 +30,11 @@ def test_live_indicator(
 
     page.evaluate("window.scrollTo(0, 0)")
 
-    page.screenshot(path=f"{screenshot_dir}/live.png", full_page=True)
-
 
 def test_mobile_live_indicator(
-    mobile_device_tuple: Tuple[Page, str],
-    set_live: Tuple[Callable, str],
-    screenshot_dir: Path,
+        mobile_device_tuple: Tuple[Page, str],
+        set_live: Tuple[Callable, str],
+        screenshot_dir: Path,
 ):
     # explicitly defining tuple objects for clarity
     replace_live_event: Callable = set_live[0]
@@ -45,10 +42,6 @@ def test_mobile_live_indicator(
 
     # set mobile page to variable
     mobile_device = mobile_device_tuple[0]
-    # set screenshot dir for mobile device
-    screenshot_dir = Path(
-        screenshot_dir / f"mobile/{mobile_device_tuple[1].replace(' ','-')}/"
-    )
 
     # intercepting reponses for live event, and make live
     replace_live_event(mobile_device, live_event)
@@ -65,7 +58,8 @@ def test_mobile_live_indicator(
     # check if live indicator is red
     assert (
         navbar.evaluate(
-            # integrated docs for python evaluate function: https://github.com/microsoft/playwright/blob/a30aac56687598c373c51255308ef5833de0c9bb/docs/src/api/class-jshandle.md?plain=1#L77-L80
+            # integrated docs for python evaluate function:
+            # https://github.com/microsoft/playwright/blob/a30aac56687598c373c51255308ef5833de0c9bb/docs/src/api/class-jshandle.md?plain=1#L77-L80
             # use evaluate function in python: https://playwright.dev/python/docs/api/class-page#page-evaluate
             # use getComputerStyle w/playwright: https://stackoverflow.com/a/71433333
             "element => window.getComputedStyle(element, ':before').backgroundColor"
@@ -79,8 +73,6 @@ def test_mobile_live_indicator(
     expect(video_player_peertube_icon).to_be_visible()
 
     mobile_device.evaluate("window.scrollTo(0, 0)")
-
-    mobile_device.screenshot(path=f"{screenshot_dir}/live-mobile.png", full_page=True)
 
     # click navbar to expand
     navbar.click()

--- a/test/external/test_matrix.py
+++ b/test/external/test_matrix.py
@@ -2,6 +2,9 @@ from pytest import mark
 from playwright.sync_api import APIRequestContext
 
 
+"""
+Call the matrix federation API to make sure the JB federation is working.
+"""
 @mark.periodic
 def test_matrix_federation(api_request_context: APIRequestContext):
     response = api_request_context.get("https://federationtester.matrix.org/api/report?server_name=jupiterbroadcasting.com")


### PR DESCRIPTION
Adds more page tests to website

- [404 Page](https://www.jupiterbroadcasting.com/404.html)
    - [x] Check for unicorn image
    - [x]  Check for "Page Not Found" text 
- Episode Page ~(1 episode each since this is templated?)~ (5 newest, 5 oldest, and any other predefined episodes we want to test)
    - [x] Tab title contains show name, episode number, and JB
    - [ ] Podverse Player
    - [ ] Support and Subscribe Buttons
    - [ ] Show Image
    - [ ] Hosts / Guests
    - [ ] Sponsors
    - [ ] Links
- Show Page ~(Should we iterate over all shows or just pick 1 since it is templated?)~ (All Shows)
    - [ ] pagination (similar to home page test)
    - [ ] Icons
    - [ ]  Hosts
- [Calendar](https://www.jupiterbroadcasting.com/calendar/)
    - [x] ~Screenshot~ Moved to playwright handling automatically
    - [ ] Check dropdown
- [Membership](https://www.jupiterbroadcasting.com/membership/)
    - [ ] Show membership links are present?
- People ([Hosts](https://www.jupiterbroadcasting.com/hosts/) and [Guests](https://www.jupiterbroadcasting.com/guests/))
    - [ ] Guest Pagination
    - [ ] All Hosts are present
-  [Live](https://www.jupiterbroadcasting.com/live/)
    - [ ] Embedded player
    - [ ] Way to mock JB being live to check live light?