### PR TITLE
updating hugo to latest version (v0.105.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.gitlab.com/pages/hugo/hugo_extended:0.101.0 as builder
+FROM registry.gitlab.com/pages/hugo/hugo_extended:0.105.0 as builder
 # this defaults to an empty variable
 ARG BASE_URL
 WORKDIR /site

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-ARG HUGO_VERSION=0.101.0
+ARG HUGO_VERSION=0.105.0
 FROM registry.gitlab.com/pages/hugo/hugo_extended:${HUGO_VERSION}
 CMD [ "serve", "-D", "--bind", "0.0.0.0" ]
 ENTRYPOINT [ "hugo" ]


### PR DESCRIPTION
want to upgrade hugo to the latest version, mainly because of this feature we need: https://github.com/JupiterBroadcasting/jupiterbroadcasting.com/pull/475#discussion_r1014647256

@gerbrent, don't know if we need to pull in @ironicbadger for this but the new container should just build (without any issues) and the deploy steps should be the exact same. So, I think it'll be fine to just merge this and let his build pipeline handle the rest. :grin:

here is an md file which has the changelog for all the changes between the versions. 

[summary.md](https://github.com/JupiterBroadcasting/jupiterbroadcasting.com/files/9946826/summary.md)
