### PR TITLE
Replace space with - in tags url

### DIFF
--- a/test/e2e/test_edge-cases.py
+++ b/test/e2e/test_edge-cases.py
@@ -1,0 +1,9 @@
+from playwright.sync_api import Page, expect
+
+"""
+Checking for broken tag links with spaces in them
+"""
+def test_tag_broken_link_spaces(page: Page):
+    page.goto("/show/linux-unplugged/489/")
+    page.locator(".tag > a", has_text="linux unplugged").click()
+    expect(page.locator(".title", has_text="Tag: linux unplugged")).to_be_visible()

--- a/themes/jb/layouts/partials/episode/tags.html
+++ b/themes/jb/layouts/partials/episode/tags.html
@@ -1,6 +1,6 @@
 {{ range $tag := . }}
   <span class="tag">
     <!-- urlquery found here: https://discourse.gohugo.io/t/url-encoding-percent-encoding-with-hugo/16546/13 -->
-    <a href="{{ `/tags/` }}{{ urlquery $tag }}/">{{$tag}}</a>
+    <a href="{{ `/tags/` }}{{ replace $tag " " "-" | urlquery }}/">{{$tag}}</a>
   </span>
 {{ end }}


### PR DESCRIPTION
This PR fixes #497.

Hello everyone! I'm kind of new here but I'm looking for new challenges so here we are :)

I noticed [`urlize`](https://gohugo.io/functions/urlize/) has been replaced with [`urlquery`](https://gohugo.io/functions/urlquery/) in #456 (Issue #319).

However, with this change the tag `c#` works, but tags with space in between don't (they did with `urlize` though).


I did some attemps and searches but couldn't find anything 100% working so the idea I had to keep the best of both worlds is to replace the empty space ` ` with `-` first (so that tags with the space are ok) and then keep urlquery for weird chars like `#` and `+`.

Tested with:
- `c# -> c%23` ok
- `c++ -> c%2B%2B` ok
- `csam scanning -> csam-scanning` ok
- `🦒 -> %F0%9F%A6%92` not ok :(

The giraffe emoji is escaped just fine, the final url is `/tags/🦒/` which I would say is correct but I can't even manually find the correct tag page. Why would you use an emoji as tag anyway? 😂