### PR TITLE
fixing typo on twitch page file path twitch logo

### DIFF
--- a/content/community/twitch.md
+++ b/content/community/twitch.md
@@ -4,7 +4,7 @@ title = "Twitch"
 description = "Twitch is an online live streaming platform."
 date = "2022-07-23T03:55:42-04:00"
 draft = false
-logo = "/images/3rd-party/Twitch.svg"
+logo = "/images/3rd-party/TwitchLogo.svg"
 comms_type = "network"
 direct_link = "https://twitch.tv/jupiterbroadcasting"
 +++


### PR DESCRIPTION
Oops sorry about the incorrect file path for the twitch logo in my last PR.
Updated correctly here. Logo file is from https://commons.wikimedia.org/wiki/File:Twitch_logo.svg
closes #496 