### PR TITLE
Fix emoji not rendering in tags

### DIFF
--- a/themes/jb/layouts/partials/episode/tags.html
+++ b/themes/jb/layouts/partials/episode/tags.html
@@ -1,6 +1,6 @@
 {{ range $tag := . }}
   <span class="tag">
     <!-- urlquery found here: https://discourse.gohugo.io/t/url-encoding-percent-encoding-with-hugo/16546/13 -->
-    <a href="{{ `/tags/` }}{{ replace $tag " " "-" | urlquery }}/">{{$tag}}</a>
+    <a href="{{ `/tags/` }}{{ replace $tag " " "-" | urlquery }}/">{{htmlUnescape $tag}}</a>
   </span>
 {{ end }}


### PR DESCRIPTION
Fixes #516. Un-escaping the Unicode characters will cause them to be rendered.

![image](https://user-images.githubusercontent.com/11327907/222197845-1ecc4738-e087-451b-ae5d-32fc9ad14a70.png)
