### PR TITLE
Set metadata properly for hosts and guests

### DIFF
--- a/themes/jb/layouts/partials/meta.html
+++ b/themes/jb/layouts/partials/meta.html
@@ -7,6 +7,19 @@
     -}}
         {{/* for all other shows */ -}}
         {{- $titleMeta = (printf `%s | %s %v | %s` .Title .Params.show_name .Params.episode .Site.Title) -}}
+    {{ else if or
+        (eq .Type `hosts`)
+        (eq .Type `guests`)
+    -}}
+        {{/* for people */ -}}
+        {{
+          $person := index (
+            where (
+              where site.RegularPages "Section" "people"
+            ) ".Params.username" .Title
+          ) 0
+        }}
+        {{- $titleMeta = (printf `%s | %s` $person.Title .Site.Title) -}}
     {{ else -}}
         {{/* covers LAN and any page that does not have a show name or episode */ -}}
         {{- $titleMeta = (printf `%s | %s` .Title .Site.Title) -}}

--- a/themes/jb/layouts/partials/meta.html
+++ b/themes/jb/layouts/partials/meta.html
@@ -19,7 +19,7 @@
             ) ".Params.username" .Title
           ) 0
         }}
-        {{- $titleMeta = (printf `%s | %s` $person.Title .Site.Title) -}}
+        {{- $titleMeta = (printf `%s | %s` (cond (eq $person.Title nil) .Title $person.Title) .Site.Title) -}}
     {{ else -}}
         {{/* covers LAN and any page that does not have a show name or episode */ -}}
         {{- $titleMeta = (printf `%s | %s` .Title .Site.Title) -}}


### PR DESCRIPTION
Because people are setup as taxonomies, a little more work needs to be done in order to properly set the page metadata.

Fixes #520 