### PR TITLE
Update matrix page to make the spaces structure clearer

### DIFF
--- a/content/community/matrix.md
+++ b/content/community/matrix.md
@@ -15,16 +15,15 @@ aliases = [
 
 ## Spaces and Rooms
 
-Jupiter Broadcasting's Rooms are organized into groups called "spaces".
+Jupiter Broadcasting's Rooms are organized into groups called `spaces` and `sub-spaces`. You join the main JB space to get access to all the rooms, or join a specific sub-space:
 
-You can find all the Jupiter Broadcasting rooms [in this space][jb-space], or join the sub-spaces you are interested in:
-
-- [Community][com-space] (this sub-space is the most active at the time of writing)
-- [Colony Meetups][meet-space]
-- [Coder Radio][cr-space]
-- [Linux Action News][lan-space]
-- [LINUX Unplugged][lup-space]
-- [Self-Hosted][sh-space]
+- [Jupiter Broadcasting Space][jb-space] - Main space which includes all of the Jupiter Broadcasting rooms and sub-spaces
+    - [Community][com-space] - JB community rooms on different topics
+    - [Colony Meetups][meet-space] - A sub-space to organize location specific meetups
+    - [Coder Radio][cr-space]
+    - [Linux Action News][lan-space]
+    - [LINUX Unplugged][lup-space]
+    - [Self-Hosted][sh-space]
 
 ## Element
 


### PR DESCRIPTION
I created a new matrix account and had to rejoin the JB spaces. When I used the matrix page for reference I got a little confused and originally thought that the community space is the main one (probably because it was the first link in the list and the comment that was near the link) and I missed the link to the main JB space :confused: 

I suspect that I might not be the only one who will find it confusing :sweat_smile:  , and therefore I made these slight modifications which I believe make things a little clearer visually
