### PR TITLE
Add urlize to remove ', but check and leave single emoji

### DIFF
--- a/themes/jb/layouts/partials/episode/tags.html
+++ b/themes/jb/layouts/partials/episode/tags.html
@@ -1,6 +1,6 @@
 {{ range $tag := . }}
   <span class="tag">
     <!-- urlquery found here: https://discourse.gohugo.io/t/url-encoding-percent-encoding-with-hugo/16546/13 -->
-    <a href="{{ `/tags/` }}{{ replace $tag " " "-" | urlquery }}/">{{$tag}}</a>
+    <a href="{{ `/tags/` }}{{ cond (ne (replace $tag " " "-" | urlize ) "") (replace $tag " " "-" | urlize) (replace $tag " " "-" | urlquery) }}/">{{$tag}}</a>
   </span>
 {{ end }}


### PR DESCRIPTION
Fixes #534 while leaving #516 (🦒) intact. This could break tags that use text and emoji. 

Somewhat of a non issue as of now hugo doesn't produce pages for emoji.