### PR TITLE
Mobile: move sponsors, clean padding, condense host/guest list

### DIFF
--- a/themes/jb/assets/css/main.sass
+++ b/themes/jb/assets/css/main.sass
@@ -7,3 +7,10 @@
 @import "helpers/_all"
 #wrapper
   padding-top: 4rem
+
+.host-list .columns
+  @include until(600px)
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    .column:first-child:last-child
+      grid-column: 1 / span 2;

--- a/themes/jb/assets/css/main.sass
+++ b/themes/jb/assets/css/main.sass
@@ -10,7 +10,7 @@
 
 .host-list .columns
   @include until(600px)
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
+    display: grid
+    grid-template-columns: repeat(2, 1fr)
     .column:first-child:last-child
-      grid-column: 1 / span 2;
+      grid-column: 1 / span 2

--- a/themes/jb/layouts/episode/single.html
+++ b/themes/jb/layouts/episode/single.html
@@ -39,8 +39,8 @@
       <div class="tile is-ancestor mt-5">
         <div class="tile is-parent is-vertical is-8">
           <!-- Hosts Section -->
-          <div class="tile is-child mb-5 columns is-multiline is-flex-grow-0">
-            <div class="column">
+          <div class="tile is-child mb-5 columns is-multiline is-flex-grow-0 hosts">
+            <div class="column px-0">
               <h2 class="has-text-centered-mobile">Hosts</h2>
               <section class="section host-list">
                 <div class="columns is-narrow">
@@ -53,7 +53,7 @@
                 </div>
               </section>
             </div>
-            <div class="column">
+            <div class="column px-0">
               {{ with .Params.guests }}
               <h2 class="has-text-centered-mobile">Guests</h2>
               <section class="section host-list">
@@ -71,20 +71,37 @@
             {{ end }}
             </div>
           </div>
+          <!-- Sponsors -->
+          <div class="tile is-child columns is-flex-grow-0 is-hidden-tablet">
+            <div class="column px-0">
+              {{ with .Params.sponsors }}
+                <h2>Sponsors</h2>
+                <section class="section px-0 sponsor-list">
+                  {{ range . }}
+                    {{ $sponsor := index (where (where site.Pages "Section" "sponsors") "Params.shortname" .) 0 }}
+                    {{ if $sponsor }}
+                      {{ partial "sponsor/small.html" $sponsor }}
+                      <br />
+                    {{ end }}
+                  {{ end }}
+                </section>
+              {{ end }}
+            </div>
+          </div>
           <!-- Episode Links -->
           <div class="tile is-child columns is-flex-grow-0">
-            <div class="column">
+            <div class="column px-0">
               {{ .Content }}
             </div>
           </div>
         </div>
         <div class="tile is-parent is-vertical is-4">
           <!-- Sponsors -->
-          <div class="tile is-child columns is-flex-grow-0">
-            <div class="column">
+          <div class="tile is-child columns is-flex-grow-0 is-hidden-mobile">
+            <div class="column px-0">
               {{ with .Params.sponsors }}
                 <h2>Sponsors</h2>
-                <section class="section sponsor-list">
+                <section class="section px-0 sponsor-list">
                   {{ range . }}
                     {{ $sponsor := index (where (where site.Pages "Section" "sponsors") "Params.shortname" .) 0 }}
                     {{ if $sponsor }}

--- a/themes/jb/layouts/episode/single.html
+++ b/themes/jb/layouts/episode/single.html
@@ -71,7 +71,7 @@
             {{ end }}
             </div>
           </div>
-          <!-- Sponsors -->
+          <!-- Sponsors: will be shown on mobile to promote sponsors -->
           <div class="tile is-child columns is-flex-grow-0 is-hidden-tablet">
             <div class="column px-0">
               {{ with .Params.sponsors }}
@@ -96,7 +96,7 @@
           </div>
         </div>
         <div class="tile is-parent is-vertical is-4">
-          <!-- Sponsors -->
+          <!-- Sponsors: will hide on mobile so sponsors can be shown above episode links -->
           <div class="tile is-child columns is-flex-grow-0 is-hidden-mobile">
             <div class="column px-0">
               {{ with .Params.sponsors }}

--- a/themes/jb/layouts/show/list.html
+++ b/themes/jb/layouts/show/list.html
@@ -41,7 +41,7 @@
         {{.Content}}
         {{ partial "show/links.html" . }}
       </div>
-      <div class="column is-half">
+      <div class="column is-half host-list">
         <h2 class="subtitle has-text-centered-mobile">Your Hosts</h2>
         <div class="columns is-multiline">
         {{ $currentPeopleSlice := where $peoplePages "Params.username" "in" .Params.hosts }}


### PR DESCRIPTION
Closes #430, adjusts padding and condenses host/guest list layout on mobile.

PR:
![localhost_1313_show_linux-unplugged_513_(iPhone XR)](https://github.com/JupiterBroadcasting/jupiterbroadcasting.com/assets/11327907/8b7c0c47-0fcc-49ca-965b-479df0d991c9)

Original:
![www jupiterbroadcasting com_show_linux-unplugged_513_(iPhone XR)](https://github.com/JupiterBroadcasting/jupiterbroadcasting.com/assets/11327907/1e37ab9e-984c-424c-8023-e8df7911b82d)
