### PR TITLE
Conditional Visibility for tags and sponsors 

### DIFF
--- a/themes/jb/layouts/episode/single.html
+++ b/themes/jb/layouts/episode/single.html
@@ -21,14 +21,14 @@
           <p>{{ .Description }} </p>
           </div>
           <div class="column is-4">
-              <center>
-                <a href="{{ .Permalink }}">
-                  <img src="{{.Params.header_image }}" width="auto" height="121" alt="{{.Title}}">
-                </a><br />
-                {{ partial "episode/support.html" . }}
-                <br/>
-                {{ partial "episode/subscribe.html" . }}
-              </center>
+            <center>
+              <a href="{{ .Permalink }}">
+                <img src="{{.Params.header_image }}" width="auto" height="121" alt="{{.Title}}">
+              </a><br />
+              {{ partial "episode/support.html" . }}
+              <br/>
+              {{ partial "episode/subscribe.html" . }}
+            </center>
           </div>
         </div>
       {{ partial "episode/podverseplayer.html" . }}

--- a/themes/jb/layouts/episode/single.html
+++ b/themes/jb/layouts/episode/single.html
@@ -21,12 +21,14 @@
           <p>{{ .Description }} </p>
           </div>
           <div class="column is-4">
-              <a href="{{ .Permalink }}">
-                <img src="{{.Params.header_image }}" width="auto" height="121" alt="{{.Title}}">
-              </a><br />
-              {{ partial "episode/support.html" . }}
-              <br/>
-              {{ partial "episode/subscribe.html" . }}
+              <center>
+                <a href="{{ .Permalink }}">
+                  <img src="{{.Params.header_image }}" width="auto" height="121" alt="{{.Title}}">
+                </a><br />
+                {{ partial "episode/support.html" . }}
+                <br/>
+                {{ partial "episode/subscribe.html" . }}
+              </center>
           </div>
         </div>
       {{ partial "episode/podverseplayer.html" . }}

--- a/themes/jb/layouts/episode/single.html
+++ b/themes/jb/layouts/episode/single.html
@@ -21,14 +21,12 @@
           <p>{{ .Description }} </p>
           </div>
           <div class="column is-4">
-            <center>
               <a href="{{ .Permalink }}">
                 <img src="{{.Params.header_image }}" width="auto" height="121" alt="{{.Title}}">
               </a><br />
               {{ partial "episode/support.html" . }}
               <br/>
               {{ partial "episode/subscribe.html" . }}
-          </center>
           </div>
         </div>
       {{ partial "episode/podverseplayer.html" . }}
@@ -97,31 +95,35 @@
         </div>
         <div class="tile is-parent is-vertical is-4">
           <!-- Sponsors: will hide on mobile so sponsors can be shown above episode links -->
-          <div class="tile is-child columns is-flex-grow-0 is-hidden-mobile">
-            <div class="column px-0">
-              {{ with .Params.sponsors }}
-                <h2>Sponsors</h2>
-                <section class="section px-0 sponsor-list">
-                  {{ range . }}
-                    {{ $sponsor := index (where (where site.Pages "Section" "sponsors") "Params.shortname" .) 0 }}
-                    {{ if $sponsor }}
-                      {{ partial "sponsor/small.html" $sponsor }}
-                      <br />
+          {{ if .Params.sponsors }}
+            <div class="tile is-child columns is-flex-grow-0 is-hidden-mobile">
+              <div class="column px-0">
+                {{ with .Params.sponsors }}
+                  <h2>Sponsors</h2>
+                  <section class="section px-0 sponsor-list">
+                    {{ range . }}
+                      {{ $sponsor := index (where (where site.Pages "Section" "sponsors") "Params.shortname" .) 0 }}
+                      {{ if $sponsor }}
+                        {{ partial "sponsor/small.html" $sponsor }}
+                        <br />
+                      {{ end }}
                     {{ end }}
-                  {{ end }}
-                </section>
+                  </section>
+                {{ end }}
+              </div>
+            </div>
+          {{ end }}
+          <!-- Tags -->
+          {{ if .Params.tags }}
+            <div class="tile is-child is-flex-grow-0">
+              <h3>Tags</h3>
+              {{ with .Params.tags }}
+                <div class="tags">
+                  {{ partial "episode/tags.html" . }}
+                </div>
               {{ end }}
             </div>
-            <!-- Tags -->
-          </div>
-          <div class="tile is-child is-flex-grow-0">
-            <h3>Tags</h3>
-            {{ with .Params.tags }}
-              <div class="tags">
-                {{ partial "episode/tags.html" . }}
-              </div>
-            {{ end }}
-          </div>
+          {{ end }}
         </div>
       </div>
     </div>

--- a/themes/jb/layouts/episode/single.html
+++ b/themes/jb/layouts/episode/single.html
@@ -70,22 +70,24 @@
             </div>
           </div>
           <!-- Sponsors: will be shown on mobile to promote sponsors -->
-          <div class="tile is-child columns is-flex-grow-0 is-hidden-tablet">
-            <div class="column px-0">
-              {{ with .Params.sponsors }}
-                <h2>Sponsors</h2>
-                <section class="section px-0 sponsor-list">
-                  {{ range . }}
-                    {{ $sponsor := index (where (where site.Pages "Section" "sponsors") "Params.shortname" .) 0 }}
-                    {{ if $sponsor }}
-                      {{ partial "sponsor/small.html" $sponsor }}
-                      <br />
+          {{ if .Params.sponsors }}
+            <div class="tile is-child columns is-flex-grow-0 is-hidden-tablet">
+              <div class="column px-0">
+                {{ with .Params.sponsors }}
+                  <h2>Sponsors</h2>
+                  <section class="section px-0 sponsor-list">
+                    {{ range . }}
+                      {{ $sponsor := index (where (where site.Pages "Section" "sponsors") "Params.shortname" .) 0 }}
+                      {{ if $sponsor }}
+                        {{ partial "sponsor/small.html" $sponsor }}
+                        <br />
+                      {{ end }}
                     {{ end }}
-                  {{ end }}
-                </section>
-              {{ end }}
+                  </section>
+                {{ end }}
+              </div>
             </div>
-          </div>
+          {{ end }}
           <!-- Episode Links -->
           <div class="tile is-child columns is-flex-grow-0">
             <div class="column px-0">


### PR DESCRIPTION
While reviewing #568 I noticed that episodes without tags displays the tags title no matter what. There is also a gap of blank space where the sponsors would be. This is due to the leftover padding and margins.

This PR adds conditions to see if these 2 pieces of data exist and if they do not, it will not render their respecitve `div`s.