### PR TITLE
Wrap guests div instead of overflowing into sponsors

### DIFF
--- a/themes/jb/layouts/episode/single.html
+++ b/themes/jb/layouts/episode/single.html
@@ -55,7 +55,7 @@
                 <div class="columns is-narrow is-multiline">
                   {{ range .Params.hosts }}
                     {{ $host := index ( where $people_sections "Params.username" .) 0 }}
-                    <div class="column is-narrow">
+                    <div class="column is-flex-grow-0">
                       {{ partial "people/smallest.html" $host }}
                     </div>
                   {{ end }}

--- a/themes/jb/layouts/episode/single.html
+++ b/themes/jb/layouts/episode/single.html
@@ -52,7 +52,7 @@
             <div class="column px-0">
               <h2 class="has-text-centered-mobile">Hosts</h2>
               <section class="section host-list">
-                <div class="columns is-narrow">
+                <div class="columns is-narrow is-multiline">
                   {{ range .Params.hosts }}
                     {{ $host := index ( where $people_sections "Params.username" .) 0 }}
                     <div class="column is-narrow">
@@ -66,7 +66,7 @@
               {{ with .Params.guests }}
               <h2 class="has-text-centered-mobile">Guests</h2>
               <section class="section host-list">
-                  <div class="columns is-narrow">
+                  <div class="columns is-narrow is-multiline">
                     {{ range . }}
                       {{ $guest := index (where $people_sections "Params.username" .) 0 }}
                       <div class="column is-narrow">

--- a/themes/jb/layouts/episode/single.html
+++ b/themes/jb/layouts/episode/single.html
@@ -69,7 +69,7 @@
                   <div class="columns is-narrow is-multiline">
                     {{ range . }}
                       {{ $guest := index (where $people_sections "Params.username" .) 0 }}
-                      <div class="column is-narrow">
+                      <div class="column is-flex-grow-0">
                         {{ if $guest }}
                           {{ partial "people/smallest.html" $guest }}
                         {{ end }}


### PR DESCRIPTION
Fixes #585

### Summary of the Fixes

The div holding the guest icons is a flexbox but `flex-wrap` isn't set.
Add [`is-multiline` which sets `flex-wrap: wrap`](https://github.com/JupiterBroadcasting/jupiterbroadcasting.com/blob/4de063a6725019cde7eda6e4481f907ed5b84024/themes/jb/assets/css/libs/bulma/sass/grid/columns.sass#L463-L464)

I added `is-multiline` to the hosts div as well for consistency.

The layout can still look a little janky because each profile pic and
name currently aren't being constrained to the same size.

Example episode pages that will be affected by this change:

https://www.jupiterbroadcasting.com/show/linux-unplugged/554/
https://www.jupiterbroadcasting.com/show/linux-unplugged/426/
https://www.jupiterbroadcasting.com/show/linux-unplugged/419/
https://www.jupiterbroadcasting.com/show/linux-unplugged/418/
https://www.jupiterbroadcasting.com/show/linux-unplugged/364/
https://www.jupiterbroadcasting.com/show/linux-unplugged/360/
