### PR TITLE
Update LUP-0554 with additional SCaLE links

### DIFF
--- a/content/show/linux-unplugged/0554.md
+++ b/content/show/linux-unplugged/0554.md
@@ -193,6 +193,8 @@
 
 ### Episode Links
 
+  * [SCaLE Network Infrastructure](https://github.com/socallinuxexpo/scale-network "socallinuxexpo/scale-network") — SCaLE's on-site expo network configurations, server deployment(NixOS), wifi(Openwrt), tooling, and scripts
+  * [SCaLE Kiosk](https://github.com/socallinuxexpo/scale-kiosk "socallinuxexpo/scale-kiosk") — SCaLE's signage and registration client NixOS Raspberry Pi image
   * [nix-community/lanzaboote](https://github.com/nix-community/lanzaboote "nix-community/lanzaboote") — Secure Boot for NixOS
   * [Eelco Dolstra’s PhD Thesis](https://edolstra.github.io/pubs/phd-thesis.pdf "Eelco Dolstra’s PhD Thesis") — The Purely Functional Software Deployment Model
   * [Docker and Nix (DockerCon 2023) \[YouTube\]](https://www.youtube.com/watch?v=l17oRkhgqHE "Docker and Nix (DockerCon 2023) [YouTube]")


### PR DESCRIPTION
## Description

Mentioned at ~8:00 min mark for Lup-0554

Figured it would be useful for the audience to have a few links to some of the SCaLE repos that power the conference each year. Included the refs at the top so its chronological with the episode.

And Id like to say a big thank you for the JB team coming down to Pasadena for NixCon and SCaLE 21x. We hope you're able to make it next year! :rocket: 