### PR TITLE
Update prod deployment command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ dev-metrics: dev-build ## Run the development hugo container with metrics
 
 deploy-prod: ## Deploy everything to production
 	docker build -t jb-jbcom .
-	docker-compose -f ~/docker-compose.yml up -d jb-jbcom
+	docker compose -f ~/docker-compose.yml up -d --force-recreate jb-jbcom
 	# docker-compose.yml located on the production host, not within this repo.
 	docker image prune -af
 


### PR DESCRIPTION
Updates the Makefile's prod deployment to use the newer `docker compose` command as well as add the `--force-recreate` flag so the container is recreated even if the container already exists.