### PR TITLE
Add check for custom RSS feed in show markdown file

### DIFF
--- a/content/show/this-week-in-bitcoin/_index.md
+++ b/content/show/this-week-in-bitcoin/_index.md
@@ -6,6 +6,7 @@ draft = false
 categories = ["This Week in Bitcoin"]
 show = "this-week-in-bitcoin"
 hosts = ["chris"]
+rss_feed = "https://serve.podhome.fm/rss/55b53584-4219-4fb0-b916-075ce23f714e"
 
 type = "show"
 active = true

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -100,7 +100,7 @@ def expected_rss_feeds() -> List[Dict[str,str,]]:
         { 'href': 'https://linuxunplugged.com/rss', 'title': 'LINUX Unplugged'},
         { 'href': 'https://www.officehours.hair/rss', 'title': 'Office Hours'},
         { 'href': 'https://selfhosted.show/rss', 'title': 'Self-Hosted'},
-        { 'href': 'https://www.thisweekinbitcoin.show/rss', 'title': 'This Week in Bitcoin'},
+        { 'href': 'https://serve.podhome.fm/rss/55b53584-4219-4fb0-b916-075ce23f714e', 'title': 'This Week in Bitcoin'},
     ]
 
 @fixture

--- a/themes/jb/layouts/partials/header.html
+++ b/themes/jb/layouts/partials/header.html
@@ -51,7 +51,11 @@
                                             <a class="dropdown-item" href="{{ site.Params.feed.video_rss }}" class="navbar-item {{ if $active }}active{{ end }}">All Shows Feed - Video</a>
                                             <a class="dropdown-item" href="{{ site.Params.feed.jupiter_station }}" class="navbar-item {{ if $active }}active{{ end }}">Jupiter Station</a>
                                             {{ range .Children }}
-                                                <a class="dropdown-item" href="{{ (site.GetPage (string .URL)).Params.links.shownotes.url }}/rss" class="navbar-item {{ if $active }}active{{ end }}">{{ .Name }}</a>
+                                                {{ if (site.GetPage (string .URL)).Params.rss_feed }}
+                                                    <a class="dropdown-item" href="{{ (site.GetPage (string .URL)).Params.rss_feed }}" class="navbar-item {{ if $active }}active{{ end }}">{{ .Name }}</a>
+                                                {{ else }}
+                                                    <a class="dropdown-item" href="{{ (site.GetPage (string .URL)).Params.links.shownotes.url }}/rss" class="navbar-item {{ if $active }}active{{ end }}">{{ .Name }}</a>
+                                                {{ end }}
                                             {{ end }}
                                         </div>
                                     </div>


### PR DESCRIPTION
Fixes #653 

TWIB does not have the forwarding setup to use https://thisweekinbitcoin.show/rss. 

So the site will now have the option to show a custom rss feed stored in the `_index.md` file for a particular show. If one is not provided in the file, then it will default to what is does currently