### PR TITLE
Add Value for Value splits

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -32,3 +32,6 @@ github_repo = "https://github.com/JupiterBroadcasting/jupiterbroadcasting.com"
 
 # Sponsor Page
 sponsors.lookbackdays = -90
+
+# Episode Page
+episode.node_link_base_url = "https://amboss.space/node/"

--- a/themes/jb/layouts/episode/single.html
+++ b/themes/jb/layouts/episode/single.html
@@ -126,6 +126,19 @@
               </div>
             </div>
           {{ end }}
+          <!-- Value for Value splits -->
+          {{ if .Params.value }}
+            <div class="tile is-child columns is-flex-grow-0" >
+              <div class="column px-0">
+                {{ with .Params.value.recipients }}
+                  <h3>Value for Value</h3>
+                  <section class="section px-0 valueforvalue">
+                    {{ partial "episode/valueforvalue.html" (dict "recipients" . "ctx" $) }}
+                  </section>
+                {{ end }}
+              </div>
+            </div>
+          {{ end }}
           <!-- Tags -->
           {{ if .Params.tags }}
             <div class="tile is-child is-flex-grow-0">

--- a/themes/jb/layouts/episode/single.html
+++ b/themes/jb/layouts/episode/single.html
@@ -131,7 +131,7 @@
             <div class="tile is-child columns is-flex-grow-0" >
               <div class="column px-0">
                 {{ with .Params.value.recipients }}
-                  <h3>Value for Value</h3>
+                  <h3>Boost Splits</h3>
                   <section class="section px-0 valueforvalue">
                     {{ partial "episode/valueforvalue.html" (dict "recipients" . "ctx" $) }}
                   </section>

--- a/themes/jb/layouts/partials/episode/valueforvalue.html
+++ b/themes/jb/layouts/partials/episode/valueforvalue.html
@@ -1,0 +1,20 @@
+<div class="card">
+  <div class="card-content">
+    <div class="content">
+      {{ $base_url := .ctx.Site.Params.episode.node_link_base_url }}
+      {{ range (sort .recipients "split" "desc") }}
+        <div class="columns mb-0">
+          <div class="column is-flex is-align-items-center">
+            <progress class="progress is-primary mb-0" value="{{ .split }}" max="100"></progress>
+            <span class="ml-2 has-text-grey">{{ .split }}%</span>
+          </div>
+          <div class="column">
+            <a href="{{ printf "%s%s" $base_url .address }}" target="_blank" rel="noopener noreferrer">
+              {{ .name }}
+            </a>
+          </div>
+        </div>
+      {{ end }}
+    </div>
+  </div>
+</div>

--- a/themes/jb/layouts/partials/episode/valueforvalue.html
+++ b/themes/jb/layouts/partials/episode/valueforvalue.html
@@ -3,7 +3,7 @@
     <div class="content">
       {{ $base_url := .ctx.Site.Params.episode.node_link_base_url }}
       {{ range (sort .recipients "split" "desc") }}
-        <div class="columns mb-0">
+        <div class="columns is-mobile">
           <div class="column is-flex is-align-items-center">
             <progress class="progress is-primary mb-0" value="{{ .split }}" max="100"></progress>
             <span class="ml-2 has-text-grey">{{ .split }}%</span>


### PR DESCRIPTION
Closes #609 

Hey, `@tarasa24:matrix.org` from `#jupiterweb:jupiterbroadcasting.com` here, thought I'd have a crack at something easy to start with to see how the processes work here. 

The new content box looks roughly like this:
![image](https://github.com/user-attachments/assets/dbf1aedf-758d-44b0-87f3-ab936fae5006)

As per the issue, split recipients are links to `https://amboss.space/node/<address>` but I made configurable so we can choose whichever provider