### PR TITLE
prune build cache on deploy

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -39,5 +39,6 @@ jobs:
             docker push ghcr.io/jupiterbroadcasting/jupiterbroadcasting.com:latest
             docker container prune -f
             docker image prune -f
+            docker builder prune -f
             docker compose -f ~/docker-compose.yml up -d jb-jbcom
           "


### PR DESCRIPTION
Deploys were failing due to the the rootfs being full. Upon inspection there was a lot of docker build cache to be cleaned up:

```
Deleted build cache objects:
znc4qay82culp422yaxu3d816
[...]
h4vkvpuyh9eiielqmvxzwrwh7

Total reclaimed space: 46GB
```

Since we are already cleaning up containers and images at deploy time, we may want to add a purge of the build cache as well.