### PR TITLE
temporarily use podhome player for the-launch

### DIFF
--- a/themes/jb/layouts/episode/single.html
+++ b/themes/jb/layouts/episode/single.html
@@ -32,7 +32,11 @@
           </div>
         </div>
       {{ if .Params.podcast_file }}
-      {{ partial "episode/podverseplayer.html" . }}
+        {{ if eq .Params.show_slug "the-launch" }}
+          {{ partial "episode/podhomeplayer.html" . }}
+        {{ else }}
+          {{ partial "episode/podverseplayer.html" . }}
+        {{ end }}
       {{else}}
       <div>
         <audio controls class="my-4" style="width: 100%;">

--- a/themes/jb/layouts/partials/episode/podhomeplayer.html
+++ b/themes/jb/layouts/partials/episode/podhomeplayer.html
@@ -1,0 +1,4 @@
+<div class="container">
+  <script type="text/javascript" async src="https://cdn.podhome.fm/player.min.js"></script>
+  <div data-m="false" data-e="{{ .Params.episode_guid }}"  data-type="podhome_player" />
+</div>


### PR DESCRIPTION
Temporarily switch to podhome player for The Launch. Intention is to switch back to podverse once they've allowlisted.

![image](https://github.com/user-attachments/assets/a8bc62db-8cdc-4581-8518-63d4bb1a4a65)
