### PR TITLE
Archive older shows

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -45,19 +45,47 @@ paginate = 12
     url = "/show/"
     weight =-90
 
+    [[Menu.Main]]
+        name = "Jupiter EXTRAS"
+        identifier = "jupiter-extras"
+        url = "/show/jupiter-extras/"
+        weight =99
+        parent = "shows"
+
+    [[Menu.Main]]
+        name = "LINUX Unplugged"
+        identifier = "linux-unplugged"
+        url = "/show/linux-unplugged/"
+        weight =91
+        parent = "shows"
+
+    [[Menu.Main]]
+        name = "Self-Hosted"
+        identifier = "self-hosted"
+        url = "/show/self-hosted/"
+        weight =92
+        parent = "shows"
+
+    [[Menu.Main]]
+        name = "This Week in Bitcoin"
+        identifier = "this-week-in-bitcoin"
+        url = "/show/this-week-in-bitcoin/"
+        weight =93
+        parent = "shows"
+
+    [[Menu.Main]]
+        name = "The Launch 🚀"
+        identifier = "the-launch"
+        url = "/show/the-launch/"
+        weight =94
+        parent = "shows"
+
 #    [[Menu.Main]]
 #        name = "Coder Radio"
 #        identifier = "coder-radio"
 #        url = "/show/coder-radio/"
 #        weight =91
 #        parent = "shows"
-
-    [[Menu.Main]]
-        name = "Jupiter EXTRAS"
-        identifier = "jupiter-extras"
-        url = "/show/jupiter-extras/"
-        weight =92
-        parent = "shows"
 
 #    [[Menu.Main]]
 #        name = "Linux Action News"
@@ -66,40 +94,12 @@ paginate = 12
 #        weight =93
 #        parent = "shows"
 
-    [[Menu.Main]]
-        name = "LINUX Unplugged"
-        identifier = "linux-unplugged"
-        url = "/show/linux-unplugged/"
-        weight =94
-        parent = "shows"
-
 #    [[Menu.Main]]
 #        name = "Office Hours"
 #        identifier = "office-hours"
 #        url = "/show/office-hours/"
 #        weight =95
 #        parent = "shows"
-
-    [[Menu.Main]]
-        name = "Self-Hosted"
-        identifier = "self-hosted"
-        url = "/show/self-hosted/"
-        weight =96
-        parent = "shows"
-
-    [[Menu.Main]]
-        name = "This Week in Bitcoin"
-        identifier = "this-week-in-bitcoin"
-        url = "/show/this-week-in-bitcoin/"
-        weight =97
-        parent = "shows"
-
-    [[Menu.Main]]
-        name = "The Launch 🚀"
-        identifier = "the-launch"
-        url = "/show/the-launch/"
-        weight =98
-        parent = "shows"
 
 [[Menu.Main]]
     name = "Sponsors"

--- a/config.toml
+++ b/config.toml
@@ -45,12 +45,12 @@ paginate = 12
     url = "/show/"
     weight =-90
 
-    [[Menu.Main]]
-        name = "Coder Radio"
-        identifier = "coder-radio"
-        url = "/show/coder-radio/"
-        weight =91
-        parent = "shows"
+#    [[Menu.Main]]
+#        name = "Coder Radio"
+#        identifier = "coder-radio"
+#        url = "/show/coder-radio/"
+#        weight =91
+#        parent = "shows"
 
     [[Menu.Main]]
         name = "Jupiter EXTRAS"
@@ -59,12 +59,12 @@ paginate = 12
         weight =92
         parent = "shows"
 
-    [[Menu.Main]]
-        name = "Linux Action News"
-        identifier = "linux-action-news"
-        url = "/show/linux-action-news/"
-        weight =93
-        parent = "shows"
+#    [[Menu.Main]]
+#        name = "Linux Action News"
+#        identifier = "linux-action-news"
+#        url = "/show/linux-action-news/"
+#        weight =93
+#        parent = "shows"
 
     [[Menu.Main]]
         name = "LINUX Unplugged"
@@ -73,12 +73,12 @@ paginate = 12
         weight =94
         parent = "shows"
 
-    [[Menu.Main]]
-        name = "Office Hours"
-        identifier = "office-hours"
-        url = "/show/office-hours/"
-        weight =95
-        parent = "shows"
+#    [[Menu.Main]]
+#        name = "Office Hours"
+#        identifier = "office-hours"
+#        url = "/show/office-hours/"
+#        weight =95
+#        parent = "shows"
 
     [[Menu.Main]]
         name = "Self-Hosted"
@@ -157,11 +157,11 @@ paginate = 12
         weight =82
         parent = "people"
 
-#[[Menu.Main]]
-    #name = "Archive"
-    #identifier = "archive"
-    #url = "/archive/"
-    #weight =90
+[[Menu.Main]]
+    name = "Archive"
+    identifier = "archive"
+    url = "/archive/"
+    weight =90
 
 [[Menu.Main]]
     name = "Community"

--- a/content/archive/_index.md
+++ b/content/archive/_index.md
@@ -9,4 +9,4 @@ header_image = "/images/logo.png"
 
 +++
 
-Here are archived Shows
+Here are archived shows.

--- a/content/show/coder-radio/_index.md
+++ b/content/show/coder-radio/_index.md
@@ -8,7 +8,7 @@ show = "coder-radio"
 hosts = ["chris","michael", "wes"]
 
 type = "show"
-active = true
+active = false
 
 header_image = "/images/shows/coder-radio.png"
 

--- a/content/show/linux-action-news/_index.md
+++ b/content/show/linux-action-news/_index.md
@@ -8,7 +8,7 @@ show = "linux-action-news"
 hosts = ["chris","wes"]
 
 type = "show"
-active = true
+active = false
 
 header_image = "/images/shows/linux-action-news.png"
 

--- a/content/show/office-hours/_index.md
+++ b/content/show/office-hours/_index.md
@@ -8,7 +8,7 @@ show = "office-hours"
 hosts = ["chris","brent"]
 
 type = "show"
-active = true
+active = false
 
 header_image = "/images/shows/office-hours.png"
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -94,11 +94,11 @@ def expected_rss_feeds() -> List[Dict[str,str,]]:
         { 'href': 'http://feeds2.feedburner.com/JupiterBroadcasting', 'title': 'All Shows Feed - Audio'},
         { 'href': 'http://feeds2.feedburner.com/AllJupiterVideos', 'title': 'All Shows Feed - Video'},
         { 'href': 'https://jupiterstation.live/rss', 'title': 'Jupiter Station'},
-        { 'href': 'https://coder.show/rss', 'title': 'Coder Radio'},
+        # { 'href': 'https://coder.show/rss', 'title': 'Coder Radio'},
         { 'href': 'https://extras.show/rss', 'title': 'Jupiter EXTRAS'},
-        { 'href': 'https://linuxactionnews.com/rss', 'title': 'Linux Action News'},
+        # { 'href': 'https://linuxactionnews.com/rss', 'title': 'Linux Action News'},
         { 'href': 'https://linuxunplugged.com/rss', 'title': 'LINUX Unplugged'},
-        { 'href': 'https://www.officehours.hair/rss', 'title': 'Office Hours'},
+        # { 'href': 'https://www.officehours.hair/rss', 'title': 'Office Hours'},
         { 'href': 'https://selfhosted.show/rss', 'title': 'Self-Hosted'},
         { 'href': 'https://serve.podhome.fm/rss/55b53584-4219-4fb0-b916-075ce23f714e', 'title': 'This Week in Bitcoin'},
         { 'href': 'https://serve.podhome.fm/rss/04b078f9-b3e8-4363-a576-98e668231306', 'title': 'The Launch 🚀'},
@@ -108,11 +108,11 @@ def expected_rss_feeds() -> List[Dict[str,str,]]:
 def expected_dropdown_items() -> Dict[str,List[Dict[str,str]]]:
     return {
         "Shows": [
-            {'href': '/show/coder-radio/', 'title': 'Coder Radio'},
+            # {'href': '/show/coder-radio/', 'title': 'Coder Radio'},
             {'href': '/show/jupiter-extras/', 'title': 'Jupiter EXTRAS'},
-            {'href': '/show/linux-action-news/', 'title': 'Linux Action News'},
+            # {'href': '/show/linux-action-news/', 'title': 'Linux Action News'},
             {'href': '/show/linux-unplugged/', 'title': 'LINUX Unplugged'},
-            {'href': '/show/office-hours/', 'title': 'Office Hours'},
+            # {'href': '/show/office-hours/', 'title': 'Office Hours'},
             {'href': '/show/self-hosted/', 'title': 'Self-Hosted'},
             {'href': '/show/this-week-in-bitcoin/', 'title': 'This Week in Bitcoin'},
             {'href': '/show/the-launch/', 'title': 'The Launch 🚀'},
@@ -154,7 +154,7 @@ def expect_nav_items() -> List[Dict[str,str]]:
         {'title': 'Garage Sale', 'href': 'https://www.jupitergarage.com/'},
         {'title': 'Membership', 'href': '/membership/'},
         # commenting out for now PR #399
-        # {'title': 'Archive', 'href': '/archive'},
+        {'title': 'Archive', 'href': '/archive/'},
         # failing on tests here: https://github.com/JupiterBroadcasting/jupiterbroadcasting.com/runs/8254156209?check_suite_focus=true#step:9:26
         {'title': 'Contact', 'href': '/contact/'},
     ]

--- a/themes/jb/layouts/index.html
+++ b/themes/jb/layouts/index.html
@@ -22,11 +22,12 @@
         {{- $all_most_recent := slice -}}
         {{- range where .Site.Sections ".Title" "Shows" -}}
          {{- range .Pages -}}
-          {{ $all_most_recent = $all_most_recent | append ((where .Pages "Type" "episode").ByDate.Reverse | first 1)  }}
+            {{ $all_most_recent = $all_most_recent | append ((where .Pages "Type" "episode" ).ByDate.Reverse | first 1)  }}
+          {{- end -}}
          {{- end -}}
-        {{- end -}}
         {{- range $all_most_recent.ByDate.Reverse -}}
          {{ with .Parent }}
+         {{ if .Params.active}}
                <div class="swiper-slide">
                  <div class="card-image">
                    <figure class="image">
@@ -40,6 +41,7 @@
                    </figure>
                  </div>
                </div>
+           {{- end -}}
            {{- end -}}
          {{ end }}
       </div>


### PR DESCRIPTION
With 8 shows on the shows list and only 4 of them actively being produced. I think it is time to move mark these shows as archived. 

Shows being archived:
- Coder Radio
- Office Hours
- Linux Action News 


What does archiving the show mean? Mostly nothing. It only does the following:
- Removes them from the "Shows" dropdown on the navbar
- Removes them from the show carousel on the homepage
- Lists the shows at  https://www.jupiterbroadcasting.com/archive/ instead