### PR TITLE
Template and link updates for TWiB on Fountain

### DIFF
--- a/content/show/coder-radio/_index.md
+++ b/content/show/coder-radio/_index.md
@@ -14,6 +14,8 @@ header_image = "/images/shows/coder-radio.png"
 
 podverse_podcast_id = "ZXd_1Ojd9"
 
+[links.support]
+  url = "/membership"
 [links.twitter]
   url = "https://twitter.com/coderradioshow"
 [links.email]

--- a/content/show/coder-radio/_index.md
+++ b/content/show/coder-radio/_index.md
@@ -28,6 +28,8 @@ podverse_podcast_id = "ZXd_1Ojd9"
   url="https://www.youtube.com/playlist?list=PLCB9545FD2C26E547"
 [links.matrix]
   url="https://matrix.to/#/#coder-radio:matrix.org"
+[links.smart-link]
+  url="https://episodes.fm/534941512"
 
 +++
 

--- a/content/show/jupiter-extras/_index.md
+++ b/content/show/jupiter-extras/_index.md
@@ -24,6 +24,8 @@ podverse_podcast_id = "0vaTwihG1R"
   url="https://twitter.com/jupiterextras"
 [links.youtube]
   url="https://www.youtube.com/playlist?list=PLUW3LUwQvegzkMxcqW0dslRJmumg6WrZi"
+[links.smart-link]
+  url="https://episodes.fm/1476447125"
 
 +++
 

--- a/content/show/jupiter-extras/_index.md
+++ b/content/show/jupiter-extras/_index.md
@@ -14,6 +14,8 @@ header_image = "/images/shows/jupiter-extras.png"
 
 podverse_podcast_id = "0vaTwihG1R"
 
+[links.support]
+  url = "/membership"
 [links.shownotes]
   url="https://extras.show"
 [links.email]

--- a/content/show/linux-action-news/_index.md
+++ b/content/show/linux-action-news/_index.md
@@ -27,6 +27,8 @@ podverse_podcast_id = "haAiVbD1N9"
   url="https://www.youtube.com/playlist?list=PLUW3LUwQvegxyaQeHQuMrDq94CT2ZZm9F"
 [links.matrix]
   url="https://matrix.to/#/#linux-action-news:matrix.org"
+[links.smart-link]
+  url="https://episodes.fm/160075139"
 
 +++
 

--- a/content/show/linux-action-news/_index.md
+++ b/content/show/linux-action-news/_index.md
@@ -15,6 +15,8 @@ header_image = "/images/shows/linux-action-news.png"
 podverse_podcast_id = "haAiVbD1N9"
 
 
+[links.support]
+  url = "/membership"
 [links.twitter]
   url = "https://twitter.com/linuxactionnews"
 [links.email]

--- a/content/show/linux-unplugged/_index.md
+++ b/content/show/linux-unplugged/_index.md
@@ -14,6 +14,8 @@ header_image = "/images/shows/linux-unplugged.png"
 
 podverse_podcast_id = "g40Um-HP1"
 
+[links.support]
+  url = "/membership"
 [links.twitter]
   url = "https://twitter.com/LINUXUnplugged"
 [links.email]

--- a/content/show/linux-unplugged/_index.md
+++ b/content/show/linux-unplugged/_index.md
@@ -32,6 +32,8 @@ podverse_podcast_id = "g40Um-HP1"
   url="https://linuxunplugged.com/articles"
 [links.youtube]
   url="https://www.youtube.com/playlist?list=PLUW3LUwQvegxVckkyK5dyyARdfjwGY-cw"
+[links.smart-link]
+  url="https://episodes.fm/687598126"
 
 +++
 

--- a/content/show/office-hours/_index.md
+++ b/content/show/office-hours/_index.md
@@ -24,6 +24,8 @@ podverse_podcast_id = "GLuztlxs0-"
   url="https://twitter.com/ChrisLAS"
 [links.youtube]
   url="https://www.youtube.com/playlist?list=PLUW3LUwQvegxr9-RTGmzRcDs7bqsI1rSP"
+[links.smart-link]
+  url="https://episodes.fm/aHR0cHM6Ly9mZWVkcy51cy1lYXN0LTEubGlub2Rlb2JqZWN0cy5jb20vb2ZmaWNlL29mZmljZS54bWw"
 
 +++
 

--- a/content/show/office-hours/_index.md
+++ b/content/show/office-hours/_index.md
@@ -14,6 +14,8 @@ header_image = "/images/shows/office-hours.png"
 
 podverse_podcast_id = "GLuztlxs0-"
 
+[links.support]
+  url = "/membership"
 [links.shownotes]
   url="https://www.officehours.hair"
 [links.email]

--- a/content/show/self-hosted/_index.md
+++ b/content/show/self-hosted/_index.md
@@ -32,6 +32,8 @@ podverse_podcast_id = "nUl1ZCL76"
   url="https://www.youtube.com/playlist?list=PLUW3LUwQvegxit4XMxUNW3qrRFmgP_aaT"
 [links.matrix]
   url="https://matrix.to/#/#self-hosted:matrix.org"
+[links.smart-link]
+  url="https://episodes.fm/1477997392"
 
 +++
 

--- a/content/show/self-hosted/_index.md
+++ b/content/show/self-hosted/_index.md
@@ -14,6 +14,8 @@ header_image = "/images/shows/self-hosted.png"
 
 podverse_podcast_id = "nUl1ZCL76"
 
+[links.support]
+  url = "/membership"
 [links.discord]
   url="https://discord.gg/U3Gvr54VRp"
 [links.twitter]

--- a/content/show/the-launch/_index.md
+++ b/content/show/the-launch/_index.md
@@ -21,6 +21,8 @@ podverse_podcast_id = "7vbU3baydv"
   url="https://www.weeklylaunch.rocks/contact"
 [links.shownotes]
   url="https://www.weeklylaunch.rocks/"
+[links.smart-link]
+  url="https://episodes.fm/1477997392"
 #[links.youtube]
 #  url="https://www.youtube.com/playlist?list=PLUW3LUwQvegxit4XMxUNW3qrRFmgP_aaT"
 #[links.matrix]

--- a/content/show/the-launch/_index.md
+++ b/content/show/the-launch/_index.md
@@ -15,6 +15,8 @@ header_image = "/images/shows/the-launch.png"
 podverse_podcast_id = "7vbU3baydv"
 
 # TODO
+[links.support]
+  url = "/membership"
 [links.email]
   url="https://www.weeklylaunch.rocks/contact"
 [links.shownotes]

--- a/content/show/this-week-in-bitcoin/_index.md
+++ b/content/show/this-week-in-bitcoin/_index.md
@@ -14,10 +14,10 @@ header_image = "/images/shows/this-week-in-bitcoin.png"
 
 podverse_podcast_id = "MxEmZU_zDt"
 
-[links.shownotes]
-  url="https://www.thisweekinbitcoin.show"
-[links.email]
-  url="/contact"
+[links.episodesfm]
+  url="https://episodes.fm/1733733790"
+[links.feed]
+  url="https://feeds.jupiterbroadcasting.com/twib"
 
 +++
 

--- a/content/show/this-week-in-bitcoin/_index.md
+++ b/content/show/this-week-in-bitcoin/_index.md
@@ -14,7 +14,7 @@ header_image = "/images/shows/this-week-in-bitcoin.png"
 
 podverse_podcast_id = "MxEmZU_zDt"
 
-[links.episodesfm]
+[links.smart-link]
   url="https://episodes.fm/1733733790"
 [links.feed]
   url="https://feeds.jupiterbroadcasting.com/twib"

--- a/themes/jb/layouts/partials/show/links.html
+++ b/themes/jb/layouts/partials/show/links.html
@@ -3,14 +3,13 @@
   <a class="link level-item pr-3" target="_blank" href="{{ (.GetPage `subscribe.md`).Permalink }}" title="subscribe">
     <div class="title fa fa-bell-ringing-o fa-3x"><span class="sr-only">subscribe</span></div>
   </a>
-  <a class="link level-item pr-3" target="_blank" href="{{ (.GetPage `/membership`).Permalink }}" title="support">
-    <div class="title fa fa-usd fa-3x"><span class="sr-only">support</span></div>
-  </a>
   {{with .Params.links}}
     {{ range $key, $value := . }}
       <a class="link level-item pr-3" target="_blank" href="{{$value.url}}" title="{{$key}}">
         {{ if eq $key "email" }}
           <div class="title fa fa-envelope fa-3x center"><span class="sr-only">{{$key}}</span></div>
+        {{ else if eq $key "support" }}
+          <div class="title fa fa-usd fa-3x"><span class="sr-only">{{$key}}</span></div>
         {{ else if eq $key "shownotes" }}
           <div class="title fa fa-pencil-square fa-3x"><span class="sr-only">{{$key}}</span></div>
         {{ else if eq $key "matrix" }}
@@ -21,6 +20,10 @@
           <div class="title fa fa-{{$key}} fa-3x"><span class="sr-only">{{$key}}</span></div>
         {{ else if eq $key "wiki" }}
           <div class="title fa fa-book fa-3x"><span class="sr-only">{{$key}}</span></div>
+        {{ else if eq $key "episodesfm" }}
+          <div class="title fa fa-podcast fa-3x"><span class="sr-only">{{$key}}</span></div>
+        {{ else if eq $key "feed" }}
+          <div class="title fa fa-rss fa-3x"><span class="sr-only">{{$key}}</span></div>
         {{ else if eq $key "blog" }}
           <div class="title fa fa-paragraph fa-3x"><span class="sr-only">{{$key}}</span></div>
         {{ else }}

--- a/themes/jb/layouts/partials/show/links.html
+++ b/themes/jb/layouts/partials/show/links.html
@@ -20,7 +20,7 @@
           <div class="title fa fa-{{$key}} fa-3x"><span class="sr-only">{{$key}}</span></div>
         {{ else if eq $key "wiki" }}
           <div class="title fa fa-book fa-3x"><span class="sr-only">{{$key}}</span></div>
-        {{ else if eq $key "episodesfm" }}
+        {{ else if eq $key "smart-link" }}
           <div class="title fa fa-podcast fa-3x"><span class="sr-only">{{$key}}</span></div>
         {{ else if eq $key "feed" }}
           <div class="title fa fa-rss fa-3x"><span class="sr-only">{{$key}}</span></div>


### PR DESCRIPTION
With TWiB moving to Fountain we'd like to use the JB.com show page as the _main_ page for the show. To support this Chris requested some link cleanup:
- Remove support link
- Remove contact link
- Remove shownotes link
- Add episodes.fm link
- Add direct RSS feed link.

To try and keep this minimally invasive functionality wise I moved the support link into the optional links and added it to all non-twib shows. Realistically, we may be fine just dropping it universally instead. In this version all that changes for non-twib shows is the ordering of the links/icons in that the support one is now further to the right. 

Open to any changes, this was just meant as a start.

![image](https://github.com/user-attachments/assets/0fd356d7-72e0-41f6-b348-efbb29016167)
