### PR TITLE
Updating Static Pages

### DIFF
--- a/content/boost/index.md
+++ b/content/boost/index.md
@@ -11,7 +11,7 @@ Boosts use the [Lightning Network](https://lightning.network/). Free software th
 
 ### Ways to Boost
 
-First you'll need some [sats](https://en.bitcoin.it/wiki/Satoshi_(unit)) and there are many ways get them. If you're in the US the simplest way we know of is to use the [Strike app](https://strike.me/) and outside the US [BlueWallet](https://bluewallet.io/). See below for a privacy focused method as well.
+First you'll need some [sats](https://en.bitcoin.it/wiki/Satoshi_(unit)) and there are many ways get them. If you're in the US the simplest way we know of is to use the [Strike app](https://strike.me/) and outside the US [BlueWallet](https://bluewallet.io/). Other options include the [Bitcoin Well](https://bitcoinwell.com/jupiter) or [River](https://www.jupiterbroadcasting.com/River). See below for a privacy focused method as well. 
 
 Once you have acquired your sats, you send them to a Podcasting 2.0 compatible app.
 

--- a/content/community/gathio.md
+++ b/content/community/gathio.md
@@ -1,0 +1,9 @@
++++
+title = "Gathio"
+description = "A simple, federated, privacy-first event hosting platform."
+date = "2025-03-11T22:18:15-06:00"
+draft = false
+logo = "https://gath.io/images/gathio-email-logo.gif"
+comms_type = "network"
+direct_link = "https://colonyevents.com/events/"
++++

--- a/content/community/meetup.md
+++ b/content/community/meetup.md
@@ -4,7 +4,7 @@ title = "Meetup"
 description = "Meetup is a platform for finding and building local communities."
 date = "2022-07-23T04:11:01-04:00"
 draft = false
-logo = "https://www.meetup.com/mu_static/en-US/logo--script.004ada05.svg"
+logo = "https://upload.wikimedia.org/wikipedia/commons/6/6b/Meetup_Logo.png"
 comms_type = "network"
 direct_link = "https://www.meetup.com/jupiterbroadcasting/"
 +++

--- a/content/community/peertube.md
+++ b/content/community/peertube.md
@@ -1,8 +1,8 @@
 +++
 title = "Peertube"
 description = "PeerTube is a free and open-source and decentralized video platform, it uses peer-to-peer technology to reduce load on individual servers when viewing videos."
-date = "2022-07-23T04:48:15-04:00"
-draft = false
+date = "2099-07-23T04:48:15-04:00"
+draft = true
 logo = "https://upload.wikimedia.org/wikipedia/commons/2/2b/Logo_de_PeerTube.svg"
 comms_type = "network"
 direct_link = "https://jupiter.tube"

--- a/content/community/picks.md
+++ b/content/community/picks.md
@@ -1,5 +1,5 @@
 +++
-title = "Picks "
+title = "Picks"
 description = "Pick Pen"
 date = "2025-02-23T21:23:01-08:00"
 draft = false

--- a/content/community/ssh-discord.md
+++ b/content/community/ssh-discord.md
@@ -1,7 +1,7 @@
 +++
 title = "Discord"
 description = "Discord is a chat platform."
-date = "2099-07-19T20:59:07-04:00"
+date = "2022-07-19T20:59:07-04:00"
 draft = true
 logo = "/images/3rd-party/DiscordLogo.svg"
 comms_type = "Self-Hosted"

--- a/content/community/ssh-discord.md
+++ b/content/community/ssh-discord.md
@@ -1,8 +1,8 @@
 +++
 title = "Discord"
 description = "Discord is a chat platform."
-date = "2022-07-19T20:59:07-04:00"
-draft = false
+date = "2099-07-19T20:59:07-04:00"
+draft = true
 logo = "/images/3rd-party/DiscordLogo.svg"
 comms_type = "Self-Hosted"
 direct_link = "https://discord.com/invite/n49fgkp"

--- a/content/community/ssh-discord.md
+++ b/content/community/ssh-discord.md
@@ -2,7 +2,7 @@
 title = "Discord"
 description = "Discord is a chat platform."
 date = "2022-07-19T20:59:07-04:00"
-draft = true
+draft = false
 logo = "/images/3rd-party/DiscordLogo.svg"
 comms_type = "Self-Hosted"
 direct_link = "https://discord.com/invite/n49fgkp"

--- a/content/community/twitter.md
+++ b/content/community/twitter.md
@@ -4,7 +4,7 @@ title = "Twitter"
 description = "Twitter is a microblogging and social networking service on which users post and interact with messages known as \"tweets\""
 date = "2022-07-23T03:51:55-04:00"
 draft = false
-logo = "https://upload.wikimedia.org/wikipedia/commons/4/4f/Twitter-logo.svg"
+logo = "https://upload.wikimedia.org/wikipedia/commons/c/ce/X_logo_2023.svg"
 comms_type = "network"
 direct_link = "https://twitter.com/jupitersignal"
 +++

--- a/content/membership/index.md
+++ b/content/membership/index.md
@@ -20,8 +20,6 @@ Access special features of every single show on the network, at a discount!
 Access special features of an individual show only.
 * [LINUX Unplugged Core Contributor](https://jupitersignal.memberful.com/checkout?plan=52946)
 
-* [Self-Hosted SRE](https://jupitersignal.memberful.com/checkout?plan=53744)
-
 ### Gift Memberships
 [Gift Memberships](https://jupitersignal.memberful.com/gift?plan=74364) are also available!
 
@@ -31,19 +29,8 @@ Access special features of an individual show only.
     * The full live version of the show, which is often packed full of exclusive content. For that raw, no-edits, straight-to-tape, extended-recording feel.
 * Ad-free version
 
-#### [Self-Hosted]({{< ref "/show/self-hosted" >}})
-* The Self-Hosted Post Show
-* Ad-free version
-
-#### [Linux Action News]({{< ref "/show/linux-action-news" >}})
-* Ad-free version
-
 
 #### [Jupiter Extras]({{< ref "/show/jupiter-extras" >}})
-* Ad-free version
-
-
-#### [Office Hours]({{< ref "/show/office-hours" >}})
 * Ad-free version
 
 #### [The Launch]({{< ref "/show/the-launch" >}})

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -129,7 +129,7 @@ def expected_dropdown_items() -> Dict[str,List[Dict[str,str]]]:
             {'href': 'https://twitter.com/jupitersignal', 'title': 'Twitter'},
             {'href': '/community/irc/', 'title': 'IRC'},
             {'href': 'http://www.facebook.com/pages/Jupiter-Broadcasting/156241429615', 'title': 'Facebook'},
-            # {'href': 'https://discord.com/invite/n49fgkp', 'title': 'Self-Hosted Discord'},
+            {'href': 'https://discord.com/invite/n49fgkp', 'title': 'Self-Hosted Discord'},
             {'href': '/community/matrix/', 'title': 'Matrix'},
             {'href': '/community/mumble/', 'title': 'Mumble'},
             {'href': 'https://t.me/jupitertelegram', 'title': 'Telegram'},

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -123,18 +123,19 @@ def expected_dropdown_items() -> Dict[str,List[Dict[str,str]]]:
         ],
         "Community": [
             {'href': 'https://github.com/JupiterBroadcasting/', 'title': 'GitHub'},
-            {'href': 'https://jupiter.tube', 'title': 'Peertube'},
+            # {'href': 'https://jupiter.tube', 'title': 'Peertube'},
             {'href': 'https://www.meetup.com/jupiterbroadcasting/', 'title': 'Meetup'},
             {'href': 'https://www.youtube.com/user/jupiterbroadcasting', 'title': 'YouTube'},
             {'href': 'https://twitter.com/jupitersignal', 'title': 'Twitter'},
             {'href': '/community/irc/', 'title': 'IRC'},
             {'href': 'http://www.facebook.com/pages/Jupiter-Broadcasting/156241429615', 'title': 'Facebook'},
-            {'href': 'https://discord.com/invite/n49fgkp', 'title': 'Self-Hosted Discord'},
+            # {'href': 'https://discord.com/invite/n49fgkp', 'title': 'Self-Hosted Discord'},
             {'href': '/community/matrix/', 'title': 'Matrix'},
             {'href': '/community/mumble/', 'title': 'Mumble'},
             {'href': 'https://t.me/jupitertelegram', 'title': 'Telegram'},
             {'href':'https://twitch.tv/jupiterbroadcasting', 'title': 'Twitch'},
             {'href': '/community/picks/', 'title': 'Picks'},
+            {'href': 'https://colonyevents.com/events/', 'title': 'Gathio'},
         ]
     }
 


### PR DESCRIPTION
- ~Hide SSH discord from community page (moved publish date to 2099)~
- Hide Peertube from community page (moved publish date to 2099)
- Add Gathio (Fixes #807  and Replaces #808)
- Update missing logos (Replaces #567)
- Add River and Bitcoin Well to boost page (closes #799)