### PR TITLE
Replace Selfhosted episodes.fm with the launch

### DIFF
--- a/content/show/the-launch/_index.md
+++ b/content/show/the-launch/_index.md
@@ -22,7 +22,7 @@ podverse_podcast_id = "7vbU3baydv"
 [links.shownotes]
   url="https://www.weeklylaunch.rocks/"
 [links.smart-link]
-  url="https://episodes.fm/1477997392"
+  url="https://episodes.fm/1729662641"
 #[links.youtube]
 #  url="https://www.youtube.com/playlist?list=PLUW3LUwQvegxit4XMxUNW3qrRFmgP_aaT"
 #[links.matrix]


### PR DESCRIPTION
The Launch had the link for Selfhosted. Correcting for The Launch.