### PR TITLE
Replace live page, add audio/video toggle

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,6 +7,10 @@ theme = 'jb'
 
 paginate = 12
 
+[params.live]
+  audio_url = "https://n12.radiojar.com/0uk94cu0xrquv?rj-ttl=5&rj-tok=AAABlr_HIYcADeN2rSDaevNY4g"
+  video_url = "https://player.restream.io/?token=7a0f9cf638004b8c9d3702120f98a300"
+
 # Footer logo and menu title config
 # footer menus are further down
 [params.footer.logo]

--- a/content/live/_index.md
+++ b/content/live/_index.md
@@ -1,5 +1,5 @@
 +++
-title = "Live "
+title = "Live Stream"
 description = "Jupiter Broadcasting live page, watch either the current or previous live stream."
 date = "2022-05-04T04:10:01-05:00"
 draft = false

--- a/themes/jb/assets/css/_components.sass
+++ b/themes/jb/assets/css/_components.sass
@@ -4,3 +4,4 @@
 @import "components/hero.sass"
 @import "components/navbar.sass"
 @import "components/picks.sass"
+@import "components/live.sass"

--- a/themes/jb/assets/css/components/live.sass
+++ b/themes/jb/assets/css/components/live.sass
@@ -1,0 +1,27 @@
+.live-container
+  display: flex
+  flex-direction: column
+  align-items: center
+
+.player-container
+    margin: 20px 0
+    width: 100%
+
+.audio-player
+    display: flex
+    justify-content: center
+
+.video-wrapper
+    position: relative
+    padding-bottom: 56.25% /* 16:9 */
+    height: 0
+
+.video-wrapper iframe
+    position: absolute
+    top: 0
+    left: 0
+    width: 100%
+    height: 100%
+
+.live-hidden
+    display: none

--- a/themes/jb/assets/js/live.js
+++ b/themes/jb/assets/js/live.js
@@ -1,0 +1,42 @@
+document.addEventListener("DOMContentLoaded", function () {
+  const audioPlayer = document.querySelector("#audio-player audio");
+  const videoPlayer = document.querySelector("#video-player iframe");
+  const audioContainer = document.querySelector("#audio-player");
+  const videoContainer = document.querySelector("#video-player");
+  const toggleButton = document.querySelector("#toggle-button");
+  const videoSrc = videoPlayer.dataset.videoSrc;
+
+  let isAudio = true;
+  let audioWasPlaying = false;
+
+  function toggleStream() {
+    if (isAudio) {
+      // Pause audio and switch to video
+      audioWasPlaying = !audioPlayer.paused;
+      audioPlayer.pause();
+      audioContainer.classList.add("live-hidden");
+      videoContainer.classList.remove("live-hidden");
+      // Load video if not loaded
+      if (videoPlayer.getAttribute("src") !== videoSrc) {
+        videoPlayer.src = videoSrc;
+      }
+      toggleButton.textContent = "Switch to Audio";
+    } else {
+      // Pause video and switch to audio.
+      // To save bandwidth, we unload the iframe.
+      videoPlayer.src = "about:blank";
+      videoContainer.classList.add("live-hidden");
+      audioContainer.classList.remove("live-hidden");
+      if (audioWasPlaying) {
+        audioPlayer.play();
+      }
+      toggleButton.textContent = "Switch to Video";
+    }
+    isAudio = !isAudio;
+    toggleButton.setAttribute("aria-pressed", !isAudio);
+  }
+
+  if (toggleButton) {
+    toggleButton.addEventListener("click", toggleStream);
+  }
+});

--- a/themes/jb/layouts/live/list.html
+++ b/themes/jb/layouts/live/list.html
@@ -1,13 +1,26 @@
 {{ define "main" }}
-  {{.Content}}
+{{ $liveJS := resources.Get "js/live.js" | js.Build "live.js" }}
+<script src="{{ $liveJS.Permalink }}"></script>
 
-    <div class="container">
-      {{ partial "live/jb-tube.html" . }}
+<div class="container live-container">
+  <h1>{{ .Title }}</h1>
+  <div class="player-container">
+    <div id="audio-player" class="audio-player">
+      <audio controls autoplay>
+        <source src="{{ .Site.Params.live.audio_url }}" type="audio/mpeg">
+        Your browser does not support the audio element.
+      </audio>
     </div>
-    <div class="container">
-      {{ partial "live/links.html" . }}
+    <div id="video-player" class="video-player live-hidden">
+      <div class="video-wrapper">
+        <iframe src="" data-video-src="{{ .Site.Params.live.video_url }}" allow="autoplay; fullscreen" allowfullscreen frameborder="0"></iframe>
+      </div>
     </div>
-    <div class="container">
-      {{ partial "live/irc.html" . }}
-    </div>
+  </div>
+  <button id="toggle-button" aria-pressed="false">Switch to Video</button>
+</div>
+
+<div class="container">
+  {{ partial "live/links.html" . }}
+</div>
 {{ end }}

--- a/themes/jb/layouts/partials/live/links.html
+++ b/themes/jb/layouts/partials/live/links.html
@@ -1,8 +1,6 @@
 <div class="my-3 has-text-centered">
-    <a href="rtmp://jb-vsn.secdn.net/jb-live/play/jblive.stream" target="_blank">[RTMP Stream]</a> | 
-    <a href="rtsp://jb-vsn.secdn.net/jb-live/play/jblive.stream" target="_blank">[RTSP Stream]</a> | 
     <a href="https://jupiter-hls.secdn.net/jupiter-channel/play/jupiter.smil/playlist.m3u8" target="_blank">[HLS Stream]</a> | 
     <a href="https://www.youtube.com/c/JupiterBroadcasting/live" target="_blank">[Youtube Stream]</a> | 
     <a href="http://jblive.fm" target="_blank">[Radio Stream]</a> | 
-    <a href="https://twitch.tv/jupiterbroadcasting" target="_blank">[Twitch Stream]</a><div>
+    <a href="https://twitch.tv/jupiterbroadcasting" target="_blank">[Twitch Stream]</a>
 </div>


### PR DESCRIPTION
This commit replaces the old live page with a new implementation that includes a toggle between audio and video streams.

Key changes:
- Introduces an audio/video player toggle on the /live page.
- Adds stream URLs to the site config.