### PR TITLE
Remove Temp IRC Embed on Live Page

### DIFF
--- a/themes/jb/layouts/live/list.html
+++ b/themes/jb/layouts/live/list.html
@@ -20,8 +20,6 @@
   <button id="toggle-button" class="button is-info" aria-pressed="false">Switch to Video</button>
 </div>
 
-{{ partial "live/irc.html" . }}
-
 <div class="container">
   {{ partial "live/links.html" . }}
 </div>


### PR DESCRIPTION
Matrix is back online, so removing this for now. 