### PR TITLE
Add missing licenses (and one description) for picks

### DIFF
--- a/data/picks/actual-budget.yaml
+++ b/data/picks/actual-budget.yaml
@@ -1,7 +1,7 @@
 ---
 description: Actual Budget is a super fast and privacy-focused app for managing your
   finances. At its heart is the well proven and much loved Envelope Budgeting methodology.
-license: null
+license: MIT
 shows:
 - episode: 627
   show: LINUX Unplugged

--- a/data/picks/atv-desktop-remote-a-simple-app-to-allow-you-to-control-an-apple-tv-from-your-desktop.yaml
+++ b/data/picks/atv-desktop-remote-a-simple-app-to-allow-you-to-control-an-apple-tv-from-your-desktop.yaml
@@ -1,7 +1,7 @@
 ---
 description: The latest version works with tvOS 15 and up. It requires Python 3 to
   be installed on the system to work properly.
-license: null
+license: MIT
 shows:
 - episode: 606
   show: LINUX Unplugged

--- a/data/picks/bitchat.yaml
+++ b/data/picks/bitchat.yaml
@@ -1,7 +1,7 @@
 ---
 description: A decentralized peer-to-peer messaging app that works over Bluetooth
   mesh networks. No internet required, no servers, no phone numbers. It's the side-groupchat.
-license: null
+license: Unlicense
 shows:
 - episode: 623
   show: LINUX Unplugged

--- a/data/picks/bpftune.yaml
+++ b/data/picks/bpftune.yaml
@@ -1,7 +1,7 @@
 ---
 description: bpftune aims to provide lightweight, always-on auto-tuning of system
   behaviour.
-license: null
+license: GPL-2.0 WITH Linux-syscall-note
 shows:
 - episode: 605
   show: LINUX Unplugged

--- a/data/picks/cavalier.yaml
+++ b/data/picks/cavalier.yaml
@@ -1,6 +1,6 @@
 ---
 description: Visualize audio with CAVA
-license: null
+license: MIT
 shows:
 - episode: 647
   show: LINUX Unplugged

--- a/data/picks/cdemu.yaml
+++ b/data/picks/cdemu.yaml
@@ -1,7 +1,7 @@
 ---
 description: CDemu is a software suite designed to emulate an optical drive and disc
   on the Linux operating system.
-license: null
+license: GPL-2.0
 shows:
 - episode: 649
   show: LINUX Unplugged

--- a/data/picks/chat-gipitty-terminal-client-for-getting-answers-from-llms.yaml
+++ b/data/picks/chat-gipitty-terminal-client-for-getting-answers-from-llms.yaml
@@ -2,7 +2,7 @@
 description: Chat Gipitty (Chat Get Information, Print Information TTY) is a command
   line client for ChatGPT. It allows you to chat with your chosen model of ChatGPT
   in a terminal and even pipe output into it.
-license: null
+license: BSD 3-Clause
 shows:
 - episode: 610
   show: LINUX Unplugged

--- a/data/picks/cheat.sh.yaml
+++ b/data/picks/cheat.sh.yaml
@@ -1,6 +1,6 @@
 ---
 description: the only cheat sheet you need.
-license: null
+license: MIT
 shows:
 - episode: 639
   show: LINUX Unplugged

--- a/data/picks/dockercomposemaker.yaml
+++ b/data/picks/dockercomposemaker.yaml
@@ -2,7 +2,7 @@
 description: DockerComposeMaker (DCM) is a self-hostable website to help you pick
   and create a docker-compose.yml file for your home server. Discover new containers,
   discover and share a config in a couple of clicks!
-license: null
+license: MIT
 shows:
 - episode: 645
   show: LINUX Unplugged

--- a/data/picks/duf.yaml
+++ b/data/picks/duf.yaml
@@ -1,6 +1,6 @@
 ---
 description: Disk Usage/Free Utility - a better 'df' alternative.
-license: null
+license: MIT, BSD
 shows:
 - episode: 639
   show: LINUX Unplugged

--- a/data/picks/easyeffects.yaml
+++ b/data/picks/easyeffects.yaml
@@ -1,7 +1,7 @@
 ---
 description: Limiter, compressor, convolver, equalizer and auto volume and many other
   plugins for PipeWire applications
-license: null
+license: GPL-3.0
 shows:
 - episode: 641
   show: LINUX Unplugged

--- a/data/picks/eilmeldung-tui-rss-reader.yaml
+++ b/data/picks/eilmeldung-tui-rss-reader.yaml
@@ -1,6 +1,6 @@
 ---
 description: A terminal-based RSS reader built on the news-flash backend.
-license: null
+license: GPL-3.0
 shows:
 - episode: 647
   show: LINUX Unplugged

--- a/data/picks/eloquent.yaml
+++ b/data/picks/eloquent.yaml
@@ -1,7 +1,7 @@
 ---
 description: Eloquent is a proofreading software for English and more than 20 other
   languages.
-license: null
+license: GPL-3.0
 shows:
 - episode: 608
   show: LINUX Unplugged

--- a/data/picks/ffshare.yaml
+++ b/data/picks/ffshare.yaml
@@ -1,7 +1,7 @@
 ---
 description: An android app to compress image, video and audio files through ffmpeg
   before sharing them
-license: null
+license: GPL-3.0
 shows:
 - episode: 627
   show: LINUX Unplugged

--- a/data/picks/gemini-cli.yaml
+++ b/data/picks/gemini-cli.yaml
@@ -1,7 +1,7 @@
 ---
 description: An open-source AI agent that brings the power of Gemini directly into
   your terminal.
-license: null
+license: Apache-2.0
 shows:
 - episode: 622
   show: LINUX Unplugged

--- a/data/picks/gopher64.yaml
+++ b/data/picks/gopher64.yaml
@@ -1,6 +1,6 @@
 ---
 description: Highly compatible N64 emulator.
-license: null
+license: GPL-3.0
 shows:
 - episode: 643
   show: LINUX Unplugged

--- a/data/picks/hexecute-🪄.yaml
+++ b/data/picks/hexecute-🪄.yaml
@@ -1,6 +1,6 @@
 ---
 description: Launch apps by casting spells!
-license: null
+license: GPL-3.0
 shows:
 - episode: 637
   show: LINUX Unplugged

--- a/data/picks/high-tide.yaml
+++ b/data/picks/high-tide.yaml
@@ -1,7 +1,7 @@
 ---
 description: Third party unofficial TIDAL music client. Listen to your favorite music
   from your desktop or mobile Linux device at the highest quality.
-license: null
+license: GPL-3.0
 shows:
 - episode: 620
   show: LINUX Unplugged

--- a/data/picks/ignition.yaml
+++ b/data/picks/ignition.yaml
@@ -1,7 +1,7 @@
 ---
 description: Ignition is a minimal app for editing autostart entries on Freedesktop-compliant
   Linux distributions.
-license: null
+license: GPL-3.0
 shows:
 - episode: 611
   show: LINUX Unplugged

--- a/data/picks/isd.yaml
+++ b/data/picks/isd.yaml
@@ -1,6 +1,6 @@
 ---
 description: isd (interactive systemd) – a better way to work with systemd units.
-license: null
+license: GPL-3.0
 shows:
 - episode: 635
   show: LINUX Unplugged

--- a/data/picks/jellify-music.yaml
+++ b/data/picks/jellify-music.yaml
@@ -1,7 +1,7 @@
 ---
 description: A cross-platform, free and open source music player for Jellyfin, powered
   by React Native
-license: null
+license: MIT
 shows:
 - episode: 645
   show: LINUX Unplugged

--- a/data/picks/junction.yaml
+++ b/data/picks/junction.yaml
@@ -1,7 +1,7 @@
 ---
 description: Junction pops up automatically when you open a file or link in another
   app.
-license: null
+license: GPL-3.0
 shows:
 - episode: 620
   show: LINUX Unplugged

--- a/data/picks/kairpods.yaml
+++ b/data/picks/kairpods.yaml
@@ -1,7 +1,7 @@
 ---
 description: Native AirPods integration for KDE Plasma 6 with real-time battery monitoring,
   noise control, and panel widget
-license: null
+license: GPL-3.0
 shows:
 - episode: 626
   show: LINUX Unplugged

--- a/data/picks/kde-control-station.yaml
+++ b/data/picks/kde-control-station.yaml
@@ -1,7 +1,7 @@
 ---
 description: A modern configuration center for KDE plasma based on the awesome kde_controlcentre
   by Prayag2
-license: null
+license: GPL-3.0
 shows:
 - episode: 626
   show: LINUX Unplugged

--- a/data/picks/kopia.yaml
+++ b/data/picks/kopia.yaml
@@ -2,7 +2,7 @@
 description: Cross-platform backup tool for Windows, macOS & Linux with fast, incremental
   backups, client-side end-to-end encryption, compression and data deduplication.
   CLI and GUI included.
-license: null
+license: Apache-2.0
 shows:
 - episode: 649
   show: LINUX Unplugged

--- a/data/picks/kvaesitso.yaml
+++ b/data/picks/kvaesitso.yaml
@@ -1,6 +1,6 @@
 ---
 description: A search-focused, free and open source launcher for Android
-license: null
+license: GPL-3.0
 shows:
 - episode: 630
   show: LINUX Unplugged

--- a/data/picks/lazyssh.yaml
+++ b/data/picks/lazyssh.yaml
@@ -1,7 +1,7 @@
 ---
 description: A terminal-based SSH manager inspired by lazydocker and k9s  but built
   for managing your fleet of servers directly from your terminal.
-license: null
+license: Apache-2.0
 shows:
 - episode: 632
   show: LINUX Unplugged

--- a/data/picks/leantime.yaml
+++ b/data/picks/leantime.yaml
@@ -1,7 +1,7 @@
 ---
 description: Leantime is a goals focused project management system for non-project
   managers. Building with ADHD, Autism, and dyslexia in mind.
-license: null
+license: AGPL-3.0
 shows:
 - episode: 645
   show: LINUX Unplugged

--- a/data/picks/lemurs-🐒.yaml
+++ b/data/picks/lemurs-🐒.yaml
@@ -1,6 +1,6 @@
 ---
 description: A customizable TUI display/login manager written in Rust
-license: null
+license: Apache-2.0, MIT
 shows:
 - episode: 638
   show: LINUX Unplugged

--- a/data/picks/lenspect.yaml
+++ b/data/picks/lenspect.yaml
@@ -1,6 +1,6 @@
 ---
-description: null
-license: null
+description: A lightweight security threat scanner powered by VirusTotal.
+license: GPL-3.0
 shows:
 - episode: 637
   show: LINUX Unplugged

--- a/data/picks/lue.yaml
+++ b/data/picks/lue.yaml
@@ -1,6 +1,6 @@
 ---
 description: Terminal eBook Reader with Text-to-Speech
-license: null
+license: GPL-3.0
 shows:
 - episode: 628
   show: LINUX Unplugged

--- a/data/picks/mazanoke.yaml
+++ b/data/picks/mazanoke.yaml
@@ -1,7 +1,7 @@
 ---
 description: MAZANOKE is a simple image optimizer that runs in your browser, works
   offline, and keeps your images private without ever leaving your device.
-license: null
+license: GPL-3.0
 shows:
 - episode: 615
   show: LINUX Unplugged

--- a/data/picks/meshsidecar.yaml
+++ b/data/picks/meshsidecar.yaml
@@ -2,7 +2,7 @@
 description: meshSidecar provides a flexible way to integrate mesh networking capabilities
   with NixOS services. It allows services to participate in mesh networks without
   requiring direct modification of the service itself.
-license: null
+license: MIT
 shows:
 - episode: 614
   show: LINUX Unplugged

--- a/data/picks/millisecond.yaml
+++ b/data/picks/millisecond.yaml
@@ -1,6 +1,6 @@
 ---
 description: Optimize your Linux system for low latency audio
-license: null
+license: GPL-3.0
 shows:
 - episode: 638
   show: LINUX Unplugged

--- a/data/picks/mqtt.yaml
+++ b/data/picks/mqtt.yaml
@@ -1,6 +1,6 @@
 ---
 description: Your All-in-one MQTT Client Toolbox
-license: null
+license: Apache-2.0
 shows:
 - episode: 648
   show: LINUX Unplugged

--- a/data/picks/mqtt5-explorer.yaml
+++ b/data/picks/mqtt5-explorer.yaml
@@ -1,7 +1,7 @@
 ---
 description: MQTT5 Explorer is a simple yet feature-rich client to visualize data
   of any MQTT broker.
-license: null
+license: GPL-3.0
 shows:
 - episode: 648
   show: LINUX Unplugged

--- a/data/picks/netop.yaml
+++ b/data/picks/netop.yaml
@@ -1,6 +1,6 @@
 ---
 description: Network Top -- Help you monitor network traffic with bpf
-license: null
+license: MIT
 shows:
 - episode: 605
   show: LINUX Unplugged

--- a/data/picks/openaudible-to-audiblebookshelf.yaml
+++ b/data/picks/openaudible-to-audiblebookshelf.yaml
@@ -3,7 +3,7 @@ description: This script automates the process of moving audiobook files from Op
   or Libation to an organized folder structure and updates AudioBookShelf accordingly.
   It handles file organization, metadata mapping, and interaction with the AudioBookShelf
   API.
-license: null
+license: AGPL-3.0
 shows:
 - episode: 604
   show: LINUX Unplugged

--- a/data/picks/papra.yaml
+++ b/data/picks/papra.yaml
@@ -1,6 +1,6 @@
 ---
 description: The minimalistic document archiving platform.
-license: null
+license: AGPL-3.0
 shows:
 - episode: 628
   show: LINUX Unplugged

--- a/data/picks/parabolic.yaml
+++ b/data/picks/parabolic.yaml
@@ -1,6 +1,6 @@
 ---
 description: A powerful yt-dlp frontend.
-license: null
+license: MIT
 shows:
 - episode: 640
   show: LINUX Unplugged

--- a/data/picks/plexripper.yaml
+++ b/data/picks/plexripper.yaml
@@ -1,7 +1,7 @@
 ---
 description: A cross-platform Plex media downloader that seamlessly adds media from
   other Plex servers to your own!
-license: null
+license: GPL-3.0
 shows:
 - episode: 626
   show: LINUX Unplugged

--- a/data/picks/pocket-tts.yaml
+++ b/data/picks/pocket-tts.yaml
@@ -1,6 +1,6 @@
 ---
 description: A high quality TTS that gives your CPU a voice.
-license: null
+license: MIT
 shows:
 - episode: 650
   show: LINUX Unplugged

--- a/data/picks/poop-(performance-optimizer-observation-platform).yaml
+++ b/data/picks/poop-(performance-optimizer-observation-platform).yaml
@@ -1,7 +1,7 @@
 ---
 description: This command line tool uses Linux's perf_event_open functionality to
   compare the performance of multiple commands with a colorful terminal user interface.
-license: null
+license: MIT
 shows:
 - episode: 636
   show: LINUX Unplugged

--- a/data/picks/pyatv-a-client-library-for-apple-tv-and-airplay-devices.yaml
+++ b/data/picks/pyatv-a-client-library-for-apple-tv-and-airplay-devices.yaml
@@ -4,7 +4,7 @@ description: This is an asyncio python library for interacting with Apple TV and
   but also supports audio streaming via AirPlay to receivers like the HomePod, AirPort
   Express and third-party speakers. It can act as remote control to the Music app/iTunes
   in macOS.
-license: null
+license: MIT
 shows:
 - episode: 606
   show: LINUX Unplugged

--- a/data/picks/rustnet.yaml
+++ b/data/picks/rustnet.yaml
@@ -3,7 +3,7 @@ description: A high-performance, cross-platform network monitoring tool built wi
   Rust. RustNet provides real-time visibility into network connections with enhanced
   state display, intelligent connection lifecycle management, deep packet inspection
   capabilities, and a responsive terminal user interface.
-license: null
+license: Apache-2.0
 shows:
 - episode: 631
   show: LINUX Unplugged

--- a/data/picks/sniffnet.yaml
+++ b/data/picks/sniffnet.yaml
@@ -1,6 +1,6 @@
 ---
 description: "Comfortably monitor your Internet traffic \U0001F575️‍♂️"
-license: null
+license: Apache-2.0, MIT
 shows:
 - episode: 622
   show: LINUX Unplugged

--- a/data/picks/somo.yaml
+++ b/data/picks/somo.yaml
@@ -1,7 +1,7 @@
 ---
 description: A human-friendly alternative to netstat for socket and port monitoring
   on Linux.
-license: null
+license: MIT
 shows:
 - episode: 619
   show: LINUX Unplugged

--- a/data/picks/spectacle-ocr-screenshot.yaml
+++ b/data/picks/spectacle-ocr-screenshot.yaml
@@ -1,7 +1,7 @@
 ---
 description: A simple utility to automatically extract text from spectacle on plasma
   desktops
-license: null
+license: MIT
 shows:
 - episode: 629
   show: LINUX Unplugged

--- a/data/picks/spectacle-ocr.yaml
+++ b/data/picks/spectacle-ocr.yaml
@@ -1,6 +1,6 @@
 ---
 description: Add OCR functionality to Spectacle
-license: null
+license: GPL-3.0
 shows:
 - episode: 629
   show: LINUX Unplugged

--- a/data/picks/ssh-studio.yaml
+++ b/data/picks/ssh-studio.yaml
@@ -1,7 +1,7 @@
 ---
 description: Easy, GUI SSH config editor and validator built with Python, GTK 4 and
   libadwaita.
-license: null
+license: GPL-3.0
 shows:
 - episode: 644
   show: LINUX Unplugged

--- a/data/picks/subgen.yaml
+++ b/data/picks/subgen.yaml
@@ -1,7 +1,7 @@
 ---
 description: Autogenerate subtitles using OpenAI Whisper Model via Jellyfin, Plex,
   Emby, Tautulli, or Bazarr.
-license: null
+license: MIT
 shows:
 - episode: 642
   show: LINUX Unplugged

--- a/data/picks/switcheroo.yaml
+++ b/data/picks/switcheroo.yaml
@@ -1,6 +1,6 @@
 ---
 description: Convert between different image filetypes and resize them easily.
-license: null
+license: GPL-3.0
 shows:
 - episode: 615
   show: LINUX Unplugged

--- a/data/picks/tab-session-manager.yaml
+++ b/data/picks/tab-session-manager.yaml
@@ -1,6 +1,6 @@
 ---
 description: WebExtensions for restoring and saving window / tab states
-license: null
+license: MPL-2.0
 shows:
 - episode: 634
   show: LINUX Unplugged

--- a/data/picks/term.everything.yaml
+++ b/data/picks/term.everything.yaml
@@ -1,6 +1,6 @@
 ---
 description: Run every GUI app in the terminal!
-license: null
+license: AGPL-3.0
 shows:
 - episode: 632
   show: LINUX Unplugged

--- a/data/picks/toney.yaml
+++ b/data/picks/toney.yaml
@@ -1,7 +1,7 @@
 ---
 description: Toney is a fast, lightweight, terminal-based note-taking app for the
   modern developer.
-license: null
+license: MIT
 shows:
 - episode: 625
   show: LINUX Unplugged

--- a/data/picks/treetrumamazon-kindle-bulk-downloader.yaml
+++ b/data/picks/treetrumamazon-kindle-bulk-downloader.yaml
@@ -2,7 +2,7 @@
 description: Allows you to bulk download all your Kindle eBook in a more automated
   fashion. This tool allows you to create backup copies of the books you've already
   purchased.
-license: null
+license: MIT
 shows:
 - episode: 603
   show: LINUX Unplugged

--- a/data/picks/ulauncher.yaml
+++ b/data/picks/ulauncher.yaml
@@ -1,6 +1,6 @@
 ---
 description: "Application launcher for Linux\U0001F427"
-license: null
+license: GPL-3.0
 shows:
 - episode: 607
   show: LINUX Unplugged

--- a/data/picks/unify.yaml
+++ b/data/picks/unify.yaml
@@ -1,6 +1,6 @@
 ---
 description: Unify is a web app aggregator built with Qt 6, Qt WebEngine, and Kirigami
-license: null
+license: GPL-3.0
 shows:
 - episode: 648
   show: LINUX Unplugged

--- a/data/picks/vtunnel.yaml
+++ b/data/picks/vtunnel.yaml
@@ -1,7 +1,7 @@
 ---
 description: vTunnel is a tool that proxies IP traffic between guest and host networks
   by using the VSOCK protocol.
-license: null
+license: BSD
 shows:
 - episode: 634
   show: LINUX Unplugged

--- a/data/picks/wakemypotato.yaml
+++ b/data/picks/wakemypotato.yaml
@@ -1,6 +1,6 @@
 ---
 description: Restart a Linux server made of a potato laptop after power outages
-license: null
+license: AGPL-3.0
 shows:
 - episode: 629
   show: LINUX Unplugged

--- a/data/picks/web-app-hub.yaml
+++ b/data/picks/web-app-hub.yaml
@@ -1,6 +1,6 @@
 ---
 description: A Web App Manager, written in rust with GTK and beautiful Adwaita.
-license: null
+license: GPL-3.0
 shows:
 - episode: 648
   show: LINUX Unplugged

--- a/data/picks/webview-kiosk.yaml
+++ b/data/picks/webview-kiosk.yaml
@@ -1,6 +1,6 @@
 ---
 description: Turn your Android device into a locked-down web page in fullscreen mode.
-license: null
+license: AGPL-3.0
 shows:
 - episode: 650
   show: LINUX Unplugged

--- a/data/picks/wlgblock.yaml
+++ b/data/picks/wlgblock.yaml
@@ -1,7 +1,7 @@
 ---
 description: This project replaces the usual password screen with a Gameboy emulator
   running a patched Pokémon game!
-license: null
+license: MIT, GPL-3.0
 shows:
 - episode: 628
   show: LINUX Unplugged

--- a/data/picks/ws4kp.yaml
+++ b/data/picks/ws4kp.yaml
@@ -1,6 +1,6 @@
 ---
 description: A web-based WeatherStar 4000
-license: null
+license: MIT
 shows:
 - episode: 617
   show: LINUX Unplugged

--- a/data/picks/youtarr.yaml
+++ b/data/picks/youtarr.yaml
@@ -2,7 +2,7 @@
 description: Youtarr is a self-hosted YouTube DVR that lets you subscribe to channels,
   browse their videos in a web UI, and automatically download and archive the ones
   you care about to your own storage.
-license: null
+license: ISC
 shows:
 - episode: 640
   show: LINUX Unplugged

--- a/data/picks/ytdl-sub.yaml
+++ b/data/picks/ytdl-sub.yaml
@@ -1,7 +1,7 @@
 ---
 description: Lightweight tool to automate downloading and metadata generation with
   yt-dlp.
-license: null
+license: GPL-3.0
 shows:
 - episode: 617
   show: LINUX Unplugged


### PR DESCRIPTION
This PR adds licenses to multiple picks that were previously missing from the `license:` field.