### PR TITLE
Move VPS deployment logic to standalone script

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -20,8 +20,9 @@ on:
 jobs:
   deploy-via-tailscale:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      # deploys using alexktz tailnet
+      # deploys using JB GitHub tailnet
       - name: Connect Tailscale
         uses: tailscale/github-action@v2
         with:
@@ -31,14 +32,5 @@ jobs:
 
       - name: Do the deploy thing
         run: |
-          ssh -o "StrictHostKeyChecking no" ironicbadger@jb-core "
-            docker login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GHCR_TOKEN }}
-            cd ${{ secrets.VPS_PROJECT_PATH }}
-            git pull
-            docker build --no-cache -t ghcr.io/jupiterbroadcasting/jupiterbroadcasting.com:latest .
-            docker push ghcr.io/jupiterbroadcasting/jupiterbroadcasting.com:latest
-            docker container prune -f
-            docker image prune -f
-            docker builder prune -f
-            docker compose -f ~/docker-compose.yml up -d jb-jbcom
-          "
+          ssh -o "StrictHostKeyChecking=no" -o "ConnectTimeout=30" ironicbadger@jb-core \
+            "PROJECT_PATH='${{ secrets.VPS_PROJECT_PATH }}' GH_ACTOR='${{ github.actor }}' GH_TOKEN='${{ secrets.GHCR_TOKEN }}' bash -s" < scripts/deploy.sh

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euo pipefail
+
+# Contract: args passed from GitHub Action runner via 'bash -s' environment
+# Fallback to positional parameters for flexibility
+PROJECT_PATH="${PROJECT_PATH:-$1}"
+GH_ACTOR="${GH_ACTOR:-$2}"
+GH_TOKEN="${GH_TOKEN:-$3}"
+
+echo "===> Entering project directory: $PROJECT_PATH"
+cd "$PROJECT_PATH"
+
+echo "===> Logging into GitHub Container Registry..."
+echo "$GH_TOKEN" | docker login ghcr.io -u "$GH_ACTOR" --password-stdin
+
+echo "===> Updating source code (fetch + hard reset)..."
+git fetch origin main
+git reset --hard origin/main
+
+echo "===> Building production Docker image..."
+docker build --no-cache -t ghcr.io/jupiterbroadcasting/jupiterbroadcasting.com:latest .
+
+echo "===> Pushing image to registry..."
+docker push ghcr.io/jupiterbroadcasting/jupiterbroadcasting.com:latest
+
+echo "===> Cleaning up Docker system (pruning)..."
+docker container prune -f
+docker image prune -f
+docker builder prune -f
+
+echo "===> Restarting services with Docker Compose..."
+docker compose -f ~/docker-compose.yml up -d jb-jbcom
+
+echo "===> Deployment successful!"


### PR DESCRIPTION
Currently, the deployment logic is embedded directly in the YAML workflow, which makes it hard to maintain, test, or lint. It also had a few issues where a failed git pull would silently continue the build.

This moves the deployment logic to `scripts/deploy.sh` and pipes it to the VPS.

Notable changes:
- Switched `git pull` to `git fetch` + `reset --hard` to avoid merge conflicts on the remote.
- Added `set -euo pipefail` so the pipeline actually stops if a command fails.
- Moved `GH_TOKEN` from a command argument to an environment variable to keep it out of the process list.
- Added a 15-minute job timeout so it doesn't hang indefinitely if the connection drops.
- Added `echo` markers to the script to show progress in the Action logs.