### PR TITLE
Replace Restream embed with direct HLS.js player

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,7 +9,7 @@ paginate = 12
 
 [params.live]
   audio_url = "https://n12.radiojar.com/0uk94cu0xrquv?rj-ttl=5&rj-tok=AAABlr_HIYcADeN2rSDaevNY4g"
-  video_url = "https://player.restream.io/?token=7a0f9cf638004b8c9d3702120f98a300"
+  video_url = "https://jupiter-hls.secdn.net/jupiter-channel/play/jupiter.smil/playlist.m3u8"
 
 # Footer logo and menu title config
 # footer menus are further down

--- a/themes/jb/assets/css/components/live.sass
+++ b/themes/jb/assets/css/components/live.sass
@@ -18,6 +18,7 @@
     justify-content: center;
     grid-template-columns: 1fr;
 
-.video-wrapper iframe
+.video-wrapper video
     width: 100%
     height: 100%
+    object-fit: contain

--- a/themes/jb/assets/js/live.js
+++ b/themes/jb/assets/js/live.js
@@ -1,30 +1,47 @@
 document.addEventListener("DOMContentLoaded", function () {
   const audioPlayer = document.querySelector("#audio-player audio");
-  const videoPlayer = document.querySelector("#video-player iframe");
+  const videoEl = document.querySelector("#hls-video");
   const toggleButton = document.querySelector("#toggle-button");
-  const videoSrc = videoPlayer.dataset.videoSrc;
+  const videoSrc = videoEl.dataset.videoSrc;
+
+  function initHls() {
+    if (typeof Hls !== "undefined" && Hls.isSupported()) {
+      let hls = new Hls();
+      hls.loadSource(videoSrc);
+      hls.attachMedia(videoEl);
+      hls.on(Hls.Events.ERROR, function (event, data) {
+        if (data.fatal) {
+          console.error("HLS fatal error:", data.type, data.details);
+        }
+      });
+      return hls;
+    } else if (videoEl.canPlayType("application/vnd.apple.mpegurl")) {
+      videoEl.src = videoSrc;
+    }
+    return null;
+  }
+
+  let hls = initHls();
 
   function toggleStream() {
-    currentMode = audioPlayer.parentNode.style.display != 'none' ? 'audio' : 'video';
+    let currentMode = audioPlayer.parentNode.style.display != 'none' ? 'audio' : 'video';
 
-    if (currentMode == 'audio')
-    {
+    if (currentMode == 'audio') {
       audioPlayer.pause();
       audioPlayer.parentNode.style.display = 'none';
 
-      videoPlayer.parentNode.style.display = '';
-      videoPlayer.src = videoPlayer.getAttribute('src') !== videoSrc ? videoSrc : '';
+      videoEl.parentNode.style.display = '';
+      videoEl.play().catch(function (e) { console.warn("Autoplay prevented:", e); });
       toggleButton.textContent = "Switch to Audio";
-    }
-    else {
-      audioPlayer.play();
-      audioPlayer.parentNode.style.display = '';
+    } else {
+      videoEl.pause();
+      videoEl.parentNode.style.display = 'none';
 
-      videoPlayer.parentNode.style.display = 'none';
-      videoPlayer.src = "about:blank";
+      audioPlayer.parentNode.style.display = '';
+      audioPlayer.play().catch(function (e) { console.warn("Autoplay prevented:", e); });
       toggleButton.textContent = "Switch to Video";
     }
-    toggleButton.setAttribute("aria-pressed", (mode == 'audio' ? true : false));
+    toggleButton.setAttribute("aria-checked", currentMode == 'audio');
   }
 
   if (toggleButton) {

--- a/themes/jb/layouts/live/list.html
+++ b/themes/jb/layouts/live/list.html
@@ -1,23 +1,24 @@
 {{ define "main" }}
 {{ $liveJS := resources.Get "js/live.js" | js.Build "live.js" }}
+<script src="https://cdn.jsdelivr.net/npm/hls.js@1.6.16" integrity="sha384-5E8B0pTlZZJMabWpC0fyYf6OUpe15jJij34BqBAh4NXoHAlLNOjCPRrwtOXOQFAn" crossorigin="anonymous"></script>
 <script src="{{ $liveJS.Permalink }}"></script>
 
 <div class="container live-container">
   <h1>{{ .Title }}</h1>
   <div class="player-container">
-    <div id="audio-player" class="audio-player">
-      <audio controls autoplay>
+    <div id="audio-player" class="audio-player" style="display:none;">
+      <audio controls>
         <source src="{{ .Site.Params.live.audio_url }}" type="audio/mpeg">
         Your browser does not support the audio element.
       </audio>
     </div>
-    <div id="video-player" class="video-player live-hidden2">
-      <div class="video-wrapper" style="display:none;">
-        <iframe src="" data-video-src="{{ .Site.Params.live.video_url }}" height="756" width="1344" allow="autoplay; fullscreen" allowfullscreen frameborder="0"></iframe>
+    <div id="video-player" class="video-player">
+      <div class="video-wrapper">
+        <video id="hls-video" controls autoplay muted playsinline webkit-playsinline data-video-src="{{ .Site.Params.live.video_url }}"></video>
       </div>
     </div>
   </div>
-  <button id="toggle-button" class="button is-info" aria-pressed="false">Switch to Video</button>
+  <button id="toggle-button" class="button is-info" role="switch" aria-checked="false">Switch to Audio</button>
 </div>
 
 <div class="container">


### PR DESCRIPTION
Swap video player to use HLS stream instead of restream embed. Also swap live page default from audio to video.