### PR TITLE
feat: add offline state to live stream player

### DIFF
--- a/themes/jb/assets/css/components/live.sass
+++ b/themes/jb/assets/css/components/live.sass
@@ -12,6 +12,7 @@
     justify-content: center
 
 .video-wrapper
+    position: relative
     display: grid;
     aspect-ratio: 16 / 9;
     place-items: center;
@@ -22,3 +23,38 @@
     width: 100%
     height: 100%
     object-fit: contain
+
+.stream-offline
+    display: none
+    position: absolute
+    top: 0
+    left: 0
+    right: 0
+    bottom: 0
+    align-items: center
+    justify-content: center
+    background: rgba(0, 0, 0, 0.9)
+    z-index: 10
+
+.stream-offline.is-visible
+    display: flex
+
+.offline-content
+    text-align: center
+
+.offline-title
+    font-size: 1.5rem
+    font-weight: bold
+    color: #fff
+    margin-bottom: 0.5rem
+
+.offline-sub
+    color: #999
+    margin-bottom: 1.25rem
+
+.offline-sub a
+    color: #3e8ed0
+    text-decoration: underline
+
+.offline-sub a:hover
+    color: #5ba3e6

--- a/themes/jb/assets/js/live.js
+++ b/themes/jb/assets/js/live.js
@@ -3,25 +3,102 @@ document.addEventListener("DOMContentLoaded", function () {
   const videoEl = document.querySelector("#hls-video");
   const toggleButton = document.querySelector("#toggle-button");
   const videoSrc = videoEl.dataset.videoSrc;
+  const offlineOverlay = document.querySelector("#stream-offline");
+  const retryButton = document.querySelector("#retry-button");
 
-  function initHls() {
-    if (typeof Hls !== "undefined" && Hls.isSupported()) {
-      let hls = new Hls();
-      hls.loadSource(videoSrc);
-      hls.attachMedia(videoEl);
-      hls.on(Hls.Events.ERROR, function (event, data) {
-        if (data.fatal) {
-          console.error("HLS fatal error:", data.type, data.details);
-        }
-      });
-      return hls;
-    } else if (videoEl.canPlayType("application/vnd.apple.mpegurl")) {
-      videoEl.src = videoSrc;
-    }
-    return null;
+  let hls = null;
+  let retryTimer = null;
+  let isOffline = false;
+  let connecting = false;
+  const RETRY_INTERVAL = 15000;
+
+  function showOffline() {
+    if (isOffline) return;
+    isOffline = true;
+    offlineOverlay.classList.add("is-visible");
   }
 
-  let hls = initHls();
+  function hideOffline() {
+    isOffline = false;
+    offlineOverlay.classList.remove("is-visible");
+  }
+
+  function destroyHls() {
+    if (hls) {
+      hls.destroy();
+      hls = null;
+    }
+  }
+
+  function startRetryTimer() {
+    stopRetryTimer();
+    retryTimer = setInterval(function () {
+      attemptConnect();
+    }, RETRY_INTERVAL);
+  }
+
+  function stopRetryTimer() {
+    if (retryTimer) {
+      clearInterval(retryTimer);
+      retryTimer = null;
+    }
+  }
+
+  function attemptConnect() {
+    if (connecting) return;
+    connecting = true;
+    destroyHls();
+
+    if (typeof Hls !== "undefined" && Hls.isSupported()) {
+      hls = new Hls();
+
+      hls.loadSource(videoSrc);
+      hls.attachMedia(videoEl);
+
+      hls.on(Hls.Events.MANIFEST_PARSED, function () {
+        connecting = false;
+        hideOffline();
+        stopRetryTimer();
+        videoEl.play().catch(function (e) {
+          console.warn("Autoplay prevented:", e);
+        });
+      });
+
+      hls.on(Hls.Events.ERROR, function (event, data) {
+        if (data.fatal) {
+          connecting = false;
+          console.error("HLS fatal error:", data.type, data.details);
+          if (data.type === Hls.ErrorTypes.NETWORK_ERROR) {
+            showOffline();
+            startRetryTimer();
+          } else if (data.type === Hls.ErrorTypes.MEDIA_ERROR) {
+            showOffline();
+            startRetryTimer();
+          } else {
+            showOffline();
+          }
+        }
+      });
+    } else if (videoEl.canPlayType("application/vnd.apple.mpegurl")) {
+      videoEl.src = videoSrc;
+
+      videoEl.addEventListener("error", function handleSafariError() {
+        connecting = false;
+        showOffline();
+        startRetryTimer();
+        videoEl.removeEventListener("error", handleSafariError);
+      });
+
+      videoEl.addEventListener("loadedmetadata", function handleSafariLoaded() {
+        connecting = false;
+        hideOffline();
+        stopRetryTimer();
+        videoEl.removeEventListener("loadedmetadata", handleSafariLoaded);
+      });
+    }
+  }
+
+  attemptConnect();
 
   function toggleStream() {
     let currentMode = audioPlayer.parentNode.style.display != 'none' ? 'audio' : 'video';
@@ -47,4 +124,17 @@ document.addEventListener("DOMContentLoaded", function () {
   if (toggleButton) {
     toggleButton.addEventListener("click", toggleStream);
   }
+
+  if (retryButton) {
+    retryButton.addEventListener("click", function () {
+      stopRetryTimer();
+      showOffline();
+      attemptConnect();
+    });
+  }
+
+  window.addEventListener("beforeunload", function () {
+    stopRetryTimer();
+    destroyHls();
+  });
 });

--- a/themes/jb/layouts/live/list.html
+++ b/themes/jb/layouts/live/list.html
@@ -15,6 +15,13 @@
     <div id="video-player" class="video-player">
       <div class="video-wrapper">
         <video id="hls-video" controls autoplay muted playsinline webkit-playsinline data-video-src="{{ .Site.Params.live.video_url }}"></video>
+        <div id="stream-offline" class="stream-offline" role="status" aria-live="polite">
+          <div class="offline-content">
+            <p class="offline-title">Currently Off Air</p>
+            <p class="offline-sub">Check the <a href="/calendar/">calendar</a> for the next live show.</p>
+            <button id="retry-button" class="button is-info">Try Again</button>
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Problem:  After #1063 swapped to `hls.js` and made video the default we no longer have a great experience for users when the stream is offline.

This change:
Detects HLS fatal errors and displays a "Currently Off Air" overlay with a link to the broadcast calendar and a manual retry button. Auto-retries connection every 15 seconds. Audio toggle remains available regardless of stream state.

Before: 
<img width="1444" height="976" alt="before" src="https://github.com/user-attachments/assets/b9a35c7f-e056-41f9-b12a-4a69c763f390" />


After: 
<img width="1444" height="976" alt="after" src="https://github.com/user-attachments/assets/764abb04-729c-468d-b0d7-2894347c230c" />
